### PR TITLE
fix: Construction of OutOfOrderTableProxy can cause newlines to be inserted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Remove the extra minus sign added to the float value after calculation. ([#341](https://github.com/python-poetry/tomlkit/issues/341))
+- Fix unexpected newline added after accessing the out-of-order table. ([#343](https://github.com/python-poetry/tomlkit/issues/343))
 
 ## [0.12.4] - 2024-02-27
 

--- a/tests/test_items.py
+++ b/tests/test_items.py
@@ -969,3 +969,30 @@ def test_custom_encoders():
 
     assert api.dumps({"foo": decimal.Decimal("1.23")}) == "foo = 1.23\n"
     api.unregister_encoder(encode_decimal)
+
+
+def test_no_extra_minus_sign():
+    doc = parse("a = -1")
+    assert doc.as_string() == "a = -1"
+    doc["a"] *= -1
+    assert doc.as_string() == "a = +1"
+    doc["a"] *= -1
+    assert doc.as_string() == "a = -1"
+
+    doc = parse("a = -1.5")
+    assert doc.as_string() == "a = -1.5"
+    doc["a"] *= -1
+    assert doc.as_string() == "a = +1.5"
+    doc["a"] *= -1
+    assert doc.as_string() == "a = -1.5"
+
+
+def test_no_newline_after_visit_oo_table():
+    content = """\
+[a.b.c.d]
+[unrelated]
+[a.b.e]
+"""
+    doc = parse(content)
+    doc["a"]
+    assert doc.as_string() == content

--- a/tomlkit/container.py
+++ b/tomlkit/container.py
@@ -794,6 +794,8 @@ class OutOfOrderTableProxy(_CustomDict):
         self._tables = []
         self._tables_map = {}
 
+        original_parsing = container._parsed
+        container.parsing(True)
         for i in indices:
             _, item = self._container._body[i]
 
@@ -805,7 +807,7 @@ class OutOfOrderTableProxy(_CustomDict):
                     self._tables_map[k] = table_idx
                     if k is not None:
                         dict.__setitem__(self, k.key, v)
-
+        container.parsing(original_parsing)
         self._internal_container._validate_out_of_order_table()
 
     def unwrap(self) -> str:


### PR DESCRIPTION
Fixes #343

Signed-off-by: Frost Ming <me@frostming.com>