### PR TITLE
fix: Revert "fix: Construction of OutOfOrderTableProxy can cause newlines to be inserted (#347)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,14 @@
 ### Fixed
 
 - Fix the incompatiblity with 3.13 because of the `datetime.replace()` change. ([#333](https://github.com/python-poetry/tomlkit/issues/333))
+- Revert the change of parsing out-of-order tables. ([#347](https://github.com/python-poetry/tomlkit/issues/347))
 
 ## [0.12.5] - 2024-05-08
 
 ### Fixed
 
 - Remove the extra minus sign added to the float value after calculation. ([#341](https://github.com/python-poetry/tomlkit/issues/341))
+- Fix unexpected newline added after accessing the out-of-order table. ([#343](https://github.com/python-poetry/tomlkit/issues/343))
 
 ## [0.12.4] - 2024-02-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - Fix the incompatiblity with 3.13 because of the `datetime.replace()` change. ([#333](https://github.com/python-poetry/tomlkit/issues/333))
 
-## [0.12.4] - 2024-05-08
+## [0.12.5] - 2024-05-08
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,6 @@
 ### Fixed
 
 - Remove the extra minus sign added to the float value after calculation. ([#341](https://github.com/python-poetry/tomlkit/issues/341))
-- Fix unexpected newline added after accessing the out-of-order table. ([#343](https://github.com/python-poetry/tomlkit/issues/343))
 
 ## [0.12.4] - 2024-02-27
 

--- a/tests/test_items.py
+++ b/tests/test_items.py
@@ -969,30 +969,3 @@ def test_custom_encoders():
 
     assert api.dumps({"foo": decimal.Decimal("1.23")}) == "foo = 1.23\n"
     api.unregister_encoder(encode_decimal)
-
-
-def test_no_extra_minus_sign():
-    doc = parse("a = -1")
-    assert doc.as_string() == "a = -1"
-    doc["a"] *= -1
-    assert doc.as_string() == "a = +1"
-    doc["a"] *= -1
-    assert doc.as_string() == "a = -1"
-
-    doc = parse("a = -1.5")
-    assert doc.as_string() == "a = -1.5"
-    doc["a"] *= -1
-    assert doc.as_string() == "a = +1.5"
-    doc["a"] *= -1
-    assert doc.as_string() == "a = -1.5"
-
-
-def test_no_newline_after_visit_oo_table():
-    content = """\
-[a.b.c.d]
-[unrelated]
-[a.b.e]
-"""
-    doc = parse(content)
-    doc["a"]
-    assert doc.as_string() == content

--- a/tests/test_items.py
+++ b/tests/test_items.py
@@ -969,3 +969,19 @@ def test_custom_encoders():
 
     assert api.dumps({"foo": decimal.Decimal("1.23")}) == "foo = 1.23\n"
     api.unregister_encoder(encode_decimal)
+
+
+def test_no_extra_minus_sign():
+    doc = parse("a = -1")
+    assert doc.as_string() == "a = -1"
+    doc["a"] *= -1
+    assert doc.as_string() == "a = +1"
+    doc["a"] *= -1
+    assert doc.as_string() == "a = -1"
+
+    doc = parse("a = -1.5")
+    assert doc.as_string() == "a = -1.5"
+    doc["a"] *= -1
+    assert doc.as_string() == "a = +1.5"
+    doc["a"] *= -1
+    assert doc.as_string() == "a = -1.5"

--- a/tomlkit/container.py
+++ b/tomlkit/container.py
@@ -792,8 +792,6 @@ class OutOfOrderTableProxy(_CustomDict):
         self._tables = []
         self._tables_map = {}
 
-        original_parsing = container._parsed
-        container.parsing(True)
         for i in indices:
             _, item = self._container._body[i]
 
@@ -805,7 +803,7 @@ class OutOfOrderTableProxy(_CustomDict):
                     self._tables_map[k] = table_idx
                     if k is not None:
                         dict.__setitem__(self, k.key, v)
-        container.parsing(original_parsing)
+
         self._internal_container._validate_out_of_order_table()
 
     def unwrap(self) -> str:

--- a/tomlkit/container.py
+++ b/tomlkit/container.py
@@ -323,8 +323,6 @@ class Container(_CustomDict):
         if key is not None:
             dict.__setitem__(self, key.key, item.value)
 
-        return self
-
     def _remove_at(self, idx: int) -> None:
         key = self._body[idx][0]
         index = self._map.get(key)


### PR DESCRIPTION
This reverts commit c2611c555261e41e1219a675cef14dd24229c607.

Resolve #351