### PR TITLE
Add a final line-ending if multi-line input string

### DIFF
--- a/tomlkit/container.py
+++ b/tomlkit/container.py
@@ -33,11 +33,12 @@ class Container(_CustomDict):
     This class implements the `dict` interface with copy/deepcopy protocol.
     """
 
-    def __init__(self, parsed: bool = False) -> None:
+    def __init__(self, parsed: bool = False, last_line_newline_added: str = "") -> None:
         self._map: dict[SingleKey, int | tuple[int, ...]] = {}
         self._body: list[tuple[Key | None, Item]] = []
         self._parsed = parsed
         self._table_keys = []
+        self._last_line_newline_added = last_line_newline_added
 
     @property
     def body(self) -> list[tuple[Key | None, Item]]:
@@ -489,6 +490,13 @@ class Container(_CustomDict):
                     s += self._render_simple_item(k, v)
             else:
                 s += self._render_simple_item(k, v)
+
+        # If we added a final newline, we must remove it now
+        if self._last_line_newline_added:
+            if s.endswith("\r\n"):
+                s = s[:-2]
+            else:
+                s = s[:-1]
 
         return s
 

--- a/tomlkit/parser.py
+++ b/tomlkit/parser.py
@@ -62,7 +62,21 @@ class Parser:
 
     def __init__(self, string: str | bytes) -> None:
         # Input to parse
-        self._src = Source(decode(string))
+        string = decode(string)
+
+        # Add correct final line-ending if needed
+        num_newline = string.count("\n")
+        self._newline_added = ""
+        if num_newline and string[-1] != "\n":
+            num_win_eol = string.count("\r\n")
+
+            if num_win_eol == num_newline:
+                self._newline_added = "\r\n"
+            else:
+                self._newline_added = "\n"
+        string += self._newline_added
+
+        self._src = Source(string)
 
         self._aot_stack: list[Key] = []
 
@@ -127,7 +141,7 @@ class Parser:
         return self._src.parse_error(exception, *args, **kwargs)
 
     def parse(self) -> TOMLDocument:
-        body = TOMLDocument(True)
+        body = TOMLDocument(True, self._newline_added)
 
         # Take all keyvals outside of tables/AoT's.
         while not self.end():


### PR DESCRIPTION
Without this final line-ending, reordering steps will fail because tables will be added directly to the previous value (see issue #381)

when creating the string from the Container again, we remove any final line-ending if we added it initially to ensure we do not modify the original behavior


This modification only fails on two unit tests. However, I do not know enough about the TOML specifiation to see why this is a problem. Is there anybody that could help out and point me to a direction on how I can fix these final two unit tests?