### PR TITLE
fix: register encoder's doc incorrectly mentions TypeError

### DIFF
--- a/tomlkit/api.py
+++ b/tomlkit/api.py
@@ -298,7 +298,7 @@ E = TypeVar("E", bound=Encoder)
 def register_encoder(encoder: E) -> E:
     """Add a custom encoder, which should be a function that will be called
     if the value can't otherwise be converted. It should takes a single value
-    and return a TOMLKit item or raise a ``TypeError``.
+    and return a TOMLKit item or raise a ``ConvertError``.
     """
     CUSTOM_ENCODERS.append(encoder)
     return encoder


### PR DESCRIPTION
Since #358, custom encoders are expected to raise a ConvertError instead of a TypeError, but the docstring of register_encoder still mentions TypeError. Fix this to mention ConvertError instead.