### PR TITLE
Fix: Inconsistent newlines on Windows

### DIFF
--- a/tests/test_toml_file.py
+++ b/tests/test_toml_file.py
@@ -106,6 +106,7 @@ def test_default_eol_is_os_linesep(tmpdir):
     with open(toml_path, "rb") as f:
         assert f.read() == b"a = 1" + linesep + b"b = 2" + linesep
 
+
 def test_readwrite_eol_windows(tmpdir):
     toml_path = str(tmpdir / "pyproject.toml")
     doc = TOMLDocument()

--- a/tests/test_toml_file.py
+++ b/tests/test_toml_file.py
@@ -105,3 +105,12 @@ def test_default_eol_is_os_linesep(tmpdir):
     linesep = os.linesep.encode()
     with open(toml_path, "rb") as f:
         assert f.read() == b"a = 1" + linesep + b"b = 2" + linesep
+
+def test_readwrite_eol_windows(tmpdir):
+    toml_path = str(tmpdir / "pyproject.toml")
+    doc = TOMLDocument()
+    doc.add("a", 1)
+    f = TOMLFile(toml_path)
+    f.write(doc)
+    readback = f.read()
+    assert doc.as_string() == readback.as_string()

--- a/tomlkit/toml_file.py
+++ b/tomlkit/toml_file.py
@@ -37,6 +37,7 @@ class TOMLFile:
                 num_win_eol = content.count("\r\n")
                 if num_win_eol == num_newline:
                     self._linesep = "\r\n"
+                    content = content.replace("\r\n", "\n")
                 elif num_win_eol == 0:
                     self._linesep = "\n"
                 else:


### PR DESCRIPTION
Fixes: #401 

Converts `\r\n` back to `\n` when reading TOML files.