### PR TITLE
Prevent repeated whitespace items in arrays

### DIFF
--- a/tests/test_items.py
+++ b/tests/test_items.py
@@ -1008,3 +1008,14 @@ def test_not_showing_parent_header_for_super_table():
     add_table(root, "first")
     add_table(root, "second")
     assert doc.as_string() == "[root.first]\n\n[root.second]\n"
+
+
+def test_removal_of_arrayitem_with_extra_whitespace():
+    expected = 'x = [\n    "bar",\n]'
+    doc = parse('x = [\n    "foo" ,#spam\n    "bar",\n]')
+    x = doc['x']
+    assert isinstance(x, Array)
+    x.remove('foo')
+    docstr = doc.as_string()
+    parse(docstr)
+    assert docstr == expected

--- a/tests/test_items.py
+++ b/tests/test_items.py
@@ -1013,9 +1013,9 @@ def test_not_showing_parent_header_for_super_table():
 def test_removal_of_arrayitem_with_extra_whitespace():
     expected = 'x = [\n    "bar",\n]'
     doc = parse('x = [\n    "foo" ,#spam\n    "bar",\n]')
-    x = doc['x']
+    x = doc["x"]
     assert isinstance(x, Array)
-    x.remove('foo')
+    x.remove("foo")
     docstr = doc.as_string()
     parse(docstr)
     assert docstr == expected

--- a/tomlkit/parser.py
+++ b/tomlkit/parser.py
@@ -595,7 +595,15 @@ class Parser:
             # consume comma
             if prev_value and self._current == ",":
                 self.inc(exception=UnexpectedEofError)
-                elems.append(Whitespace(","))
+                # Check if the previous item is Whitespace
+                if isinstance(elems[-1], Whitespace) and " " in elems[-1].s:
+                    # Preserve the previous whitespace
+                    comma = Whitespace(elems[-1].s + ",")
+                    # Remove the replaced item
+                    del elems[-1]
+                else:
+                    comma = Whitespace(",")
+                elems.append(comma)
                 prev_value = False
                 continue
 


### PR DESCRIPTION
Fixes: #405

This prevents the trailing whitespace on an item from being incorrectly grouped.

```python
>>> from tomlkit import parse
>>> doc = parse('x = [\n    "foo" ,#spam\n    "bar",\n]')
>>> print(repr(doc["x"]))
# Before, reformatted
[
    (<Whitespace '\n    '>, 'foo'),
    (<Whitespace ' '>, <Null>, <Whitespace ','>, <Comment 'spam'>),
    (<Whitespace '\n    '>, 'bar', <Whitespace ','>),
    (<Whitespace '\n'>,)
]

# After, reformatted
[
    (<Whitespace '\n    '>, 'foo', <Whitespace ' ,'>, <Comment 'spam'>),
    (<Whitespace '\n    '>, 'bar', <Whitespace ','>),
    (<Whitespace '\n'>,)
]
```

```python
>>> doc["x"].remove("foo")
>>> print(doc.as_string())
```
```toml
# Before
x = [,#spam
    "bar",
]

# After
x = [
    "bar",
]
```
