### PR TITLE
Aot __setitem__ not implemented fix

### DIFF
--- a/tests/test_items.py
+++ b/tests/test_items.py
@@ -128,6 +128,14 @@ def test_aot_unwrap():
             assert_is_ppo(ku, str)
             assert_is_ppo(vu, str)
 
+def test_aot_set_item():
+    d = item(["A", {"b": "B"}])
+    d[0] = "C"
+    assert d[0] == "C"
+    d[1]["b"] = "D"
+    assert d[1]["b"] == "D"
+    d[0] =  {"c": "C"}
+    assert d[0]["c"] == "C"
 
 def test_time_unwrap():
     t = time(3, 8, 14)
@@ -1019,3 +1027,5 @@ def test_removal_of_arrayitem_with_extra_whitespace():
     docstr = doc.as_string()
     parse(docstr)
     assert docstr == expected
+
+

--- a/tests/test_items.py
+++ b/tests/test_items.py
@@ -12,7 +12,7 @@ import pytest
 
 from tests.util import assert_is_ppo
 from tests.util import elementary_test
-from tomlkit import api
+from tomlkit import api, value
 from tomlkit import parse
 from tomlkit.exceptions import NonExistentKey
 from tomlkit.items import Array
@@ -129,13 +129,16 @@ def test_aot_unwrap():
             assert_is_ppo(vu, str)
 
 def test_aot_set_item():
-    d = item(["A", {"b": "B"}])
+    d = item(["A", {"b": "B"}, ["c", "D"]])
     d[0] = "C"
+    assert isinstance(d[0], String)
     assert d[0] == "C"
     d[1]["b"] = "D"
+    assert isinstance(d[1], InlineTable)
     assert d[1]["b"] == "D"
-    d[0] =  {"c": "C"}
-    assert d[0]["c"] == "C"
+    d[0] =  ["c", "C"]
+    assert isinstance(d[0], Array)
+    assert d[0][1] == "C"
 
 def test_time_unwrap():
     t = time(3, 8, 14)

--- a/tests/test_items.py
+++ b/tests/test_items.py
@@ -12,7 +12,7 @@ import pytest
 
 from tests.util import assert_is_ppo
 from tests.util import elementary_test
-from tomlkit import api, value
+from tomlkit import api
 from tomlkit import parse
 from tomlkit.exceptions import NonExistentKey
 from tomlkit.items import Array
@@ -128,6 +128,7 @@ def test_aot_unwrap():
             assert_is_ppo(ku, str)
             assert_is_ppo(vu, str)
 
+
 def test_aot_set_item():
     d = item(["A", {"b": "B"}, ["c", "D"]])
     d[0] = "C"
@@ -136,9 +137,10 @@ def test_aot_set_item():
     d[1]["b"] = "D"
     assert isinstance(d[1], InlineTable)
     assert d[1]["b"] == "D"
-    d[0] =  ["c", "C"]
+    d[0] = ["c", "C"]
     assert isinstance(d[0], Array)
     assert d[0][1] == "C"
+
 
 def test_time_unwrap():
     t = time(3, 8, 14)
@@ -1030,5 +1032,3 @@ def test_removal_of_arrayitem_with_extra_whitespace():
     docstr = doc.as_string()
     parse(docstr)
     assert docstr == expected
-
-

--- a/tomlkit/items.py
+++ b/tomlkit/items.py
@@ -1885,7 +1885,7 @@ class AoT(Item, _CustomList):
         return self._body[key]
 
     def __setitem__(self, key: slice | int, value: Any) -> None:
-        raise NotImplementedError
+        self._body[key] = item(value, _parent=self)
 
     def __delitem__(self, key: slice | int) -> None:
         del self._body[key]


### PR DESCRIPTION
AOT did  not implement __setitem__ and it looked like an oversight.
Tried to implement it add added tests to the best of my understanding, checking that the types returned after setting value, maps or array or of the proper type and properly unwrapped.