### PR TITLE
Fix: reject single keys that aren't strings

### DIFF
--- a/tests/test_toml_document.py
+++ b/tests/test_toml_document.py
@@ -15,6 +15,7 @@ from tomlkit import ws
 from tomlkit._utils import _utc
 from tomlkit.api import document
 from tomlkit.exceptions import NonExistentKey
+from tomlkit.toml_document import TOMLDocument
 
 
 def test_document_is_a_dict(example):
@@ -1187,3 +1188,7 @@ name = "baz"
 
 """
     )
+
+
+def test_set_default_int():
+    TOMLDocument().setdefault(4, 5)

--- a/tests/test_toml_document.py
+++ b/tests/test_toml_document.py
@@ -1191,4 +1191,5 @@ name = "baz"
 
 
 def test_set_default_int():
-    TOMLDocument().setdefault(4, 5)
+    with pytest.raises(TypeError):
+        TOMLDocument().setdefault(4, 5)

--- a/tomlkit/items.py
+++ b/tomlkit/items.py
@@ -375,14 +375,13 @@ class SingleKey(Key):
 
     def __init__(
         self,
-        k: str | int,
+        k: str,
         t: KeyType | None = None,
         sep: str | None = None,
         original: str | None = None,
     ) -> None:
-        # keys are allowed to be ints but should be interpreted as strings
         if not isinstance(k, str):
-            k = str(k)
+            raise TypeError("Keys must be strings")
 
         if t is None:
             if not k or any(

--- a/tomlkit/items.py
+++ b/tomlkit/items.py
@@ -375,11 +375,15 @@ class SingleKey(Key):
 
     def __init__(
         self,
-        k: str,
+        k: str | int,
         t: KeyType | None = None,
         sep: str | None = None,
         original: str | None = None,
     ) -> None:
+        # keys are allowed to be ints but should be interpreted as strings
+        if not isinstance(k, str):
+            k = str(k)
+
         if t is None:
             if not k or any(
                 c not in string.ascii_letters + string.digits + "-" + "_" for c in k


### PR DESCRIPTION
Fixes #412 

As per the spec, int keys are allowed but should be treated as strings, therefore, we just cast it to a string if it isn't one. 