### PR TITLE
fix: ensure unique table indices when adding items to out-of-order tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 
+- Fix non-existing key error when deleting an item from an out-of-order table. ([#383](https://github.com/python-poetry/tomlkit/issues/383))
 - Fix repeated whitespace when removing an array item. ([#405](https://github.com/python-poetry/tomlkit/issues/405))
 - Fix invalid serialization after removing array item if the comma is on its own line. ([#408](https://github.com/python-poetry/tomlkit/issues/408))
 - Fix serialization of a nested dotted key table. ([#411](https://github.com/python-poetry/tomlkit/issues/411))

--- a/tests/test_toml_document.py
+++ b/tests/test_toml_document.py
@@ -1231,3 +1231,27 @@ z = 3
 bar = {open = true}
 """
     )
+
+
+def test_delete_key_from_out_of_order_table():
+    content = """\
+[foo.bar.baz]
+a = 1
+[foo.bar]
+b = 2
+[other]
+c = 3
+[foo.tee]
+d = 4
+"""
+    doc = parse(content)
+    del doc["foo"]["bar"]
+    assert (
+        doc.as_string()
+        == """\
+[other]
+c = 3
+[foo.tee]
+d = 4
+"""
+    )

--- a/tomlkit/container.py
+++ b/tomlkit/container.py
@@ -814,7 +814,9 @@ class OutOfOrderTableProxy(_CustomDict):
                 table_idx = len(self._tables) - 1
                 for k, v in item.value.body:
                     self._internal_container._raw_append(k, v)
-                    self._tables_map.setdefault(k, []).append(table_idx)
+                    indices = self._tables_map.setdefault(k, [])
+                    if table_idx not in indices:
+                        indices.append(table_idx)
                     if k is not None:
                         dict.__setitem__(self, k.key, v)
 


### PR DESCRIPTION
Fix #383

Signed-off-by: Frost Ming <me@frostming.com>