### PR TITLE
fix: Missing newline at end of file with multiple array of tables can corrupt during dumping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 
+- Fix missing newline when parsing a separated array of tables without trailing new line. ([#381](https://github.com/python-poetry/tomlkit/issues/381))
 - Fix non-existing key error when deleting an item from an out-of-order table. ([#383](https://github.com/python-poetry/tomlkit/issues/383))
 - Ensure newline is added between the plain values and the first table. ([#387](https://github.com/python-poetry/tomlkit/issues/387))
 - Fix repeated whitespace when removing an array item. ([#405](https://github.com/python-poetry/tomlkit/issues/405))

--- a/tests/test_toml_document.py
+++ b/tests/test_toml_document.py
@@ -1257,3 +1257,39 @@ c = 3
 d = 4
 """
     )
+
+
+def test_parse_aot_without_ending_newline():
+    content = '''\
+[[products]]
+name = "Hammer"
+
+[foo]
+
+[bar]
+
+[[products]]
+name = "Nail"'''
+    doc = parse(content)
+    assert (
+        doc.as_string()
+        == """\
+[[products]]
+name = "Hammer"
+
+[[products]]
+name = "Nail"
+[foo]
+
+[bar]
+
+"""
+    )
+    assert doc == {
+        "products": [
+            {"name": "Hammer"},
+            {"name": "Nail"},
+        ],
+        "foo": {},
+        "bar": {},
+    }

--- a/tomlkit/container.py
+++ b/tomlkit/container.py
@@ -488,8 +488,20 @@ class Container(_CustomDict):
         for k, v in self._body:
             if k is not None:
                 if isinstance(v, Table):
+                    if (
+                        s.strip(" ")
+                        and not s.strip(" ").endswith("\n")
+                        and "\n" not in v.trivia.indent
+                    ):
+                        s += "\n"
                     s += self._render_table(k, v)
                 elif isinstance(v, AoT):
+                    if (
+                        s.strip(" ")
+                        and not s.strip(" ").endswith("\n")
+                        and "\n" not in v.trivia.indent
+                    ):
+                        s += "\n"
                     s += self._render_aot(k, v)
                 else:
                     s += self._render_simple_item(k, v)
@@ -538,6 +550,12 @@ class Container(_CustomDict):
 
         for k, v in table.value.body:
             if isinstance(v, Table):
+                if (
+                    cur.strip(" ")
+                    and not cur.strip(" ").endswith("\n")
+                    and "\n" not in v.trivia.indent
+                ):
+                    cur += "\n"
                 if v.is_super_table():
                     if k.is_dotted() and not key.is_dotted():
                         # Dotted key inside table
@@ -547,6 +565,12 @@ class Container(_CustomDict):
                 else:
                     cur += self._render_table(k, v, prefix=_key)
             elif isinstance(v, AoT):
+                if (
+                    cur.strip(" ")
+                    and not cur.strip(" ").endswith("\n")
+                    and "\n" not in v.trivia.indent
+                ):
+                    cur += "\n"
                 cur += self._render_aot(k, v, prefix=_key)
             else:
                 cur += self._render_simple_item(


### PR DESCRIPTION
Fixes #381

Signed-off-by: Frost Ming <me@frostming.com>