### PR TITLE
fix: Add DottedKey to a super table gives wrong output (#431)

### DIFF
--- a/tests/test_toml_document.py
+++ b/tests/test_toml_document.py
@@ -1293,3 +1293,24 @@ name = "Nail"
         "foo": {},
         "bar": {},
     }
+
+
+def test_appending_to_super_table():
+    content = """\
+[a.b]
+value = 5
+"""
+
+    doc = parse(content)
+    table_a = doc["a"]
+    table_a.append(tomlkit.key(["c", "d"]), "foo")
+
+    expected = """\
+[a]
+c.d = "foo"
+
+[a.b]
+value = 5
+"""
+
+    assert doc.as_string() == expected

--- a/tomlkit/container.py
+++ b/tomlkit/container.py
@@ -521,12 +521,19 @@ class Container(_CustomDict):
             if prefix is not None:
                 _key = prefix + "." + _key
 
-        if not table.is_super_table() or (
-            any(
-                not isinstance(v, (Table, AoT, Whitespace, Null))
-                for _, v in table.value.body
+        if (
+            not table.is_super_table()
+            or (
+                any(
+                    not isinstance(v, (Table, AoT, Whitespace, Null))
+                    for _, v in table.value.body
+                )
+                and not key.is_dotted()
             )
-            and not key.is_dotted()
+            or (
+                any(k.is_dotted() for k, v in table.value.body if isinstance(v, Table))
+                and not key.is_dotted()
+            )
         ):
             open_, close = "[", "]"
             if table.is_aot_element():


### PR DESCRIPTION
When a table is already a super table, appending dotted items to it will result in wrong behavior. The header was missing, so the final result was an incorrect representation of the document.

Because super_table is already set and can no longer be re-evaluated, I have added a check to the renderer instead, so that it can determine if the header should be rendered.

I have not gone through different edge cases, but it seems that all other tests are still passing.