### PR TITLE
escape or reject a bare carriage return in multiline strings

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -511,6 +511,10 @@ def test_create_super_table_with_aot() -> None:
         ({"multiline": True}, 'My""String', '"""My""String"""'),
         ({"multiline": True}, 'My"""String', '"""My""\\"String"""'),
         ({"multiline": True}, 'My""""String', '"""My""\\""String"""'),
+        # a lone CR is a control char and is escaped, but a CRLF line ending is
+        # left intact
+        ({"multiline": True}, "My\rString", '"""My\\rString"""'),
+        ({"multiline": True}, "My\r\nString", '"""My\r\nString"""'),
         (
             {"multiline": True},
             '"""My"""Str"""ing"""',
@@ -572,6 +576,9 @@ def test_create_multiline_string_with_leading_newline_round_trips(
         ({"literal": True}, "My\x0cString"),
         ({"literal": True}, "My\x7fString"),
         ({"multiline": True, "literal": True}, "My'''String"),
+        # a lone CR cannot be represented in a multiline literal string
+        ({"multiline": True, "literal": True}, "My\rString"),
+        ({"multiline": True, "literal": True}, "My\r\nMy\rString"),
     ],
 )
 def test_create_string_with_invalid_characters(

--- a/tomlkit/items.py
+++ b/tomlkit/items.py
@@ -234,7 +234,7 @@ def item(value: Any, _parent: Item | None = None, _sort_keys: bool = False) -> I
 
 # A carriage return that is not the CR of a CRLF line ending. Inside a multiline
 # string only a raw line feed or a CRLF pair is a valid line ending; a lone CR is
-# a control character. Literal strings cannot escape it, basic strings must.
+# a control character that a basic string must escape.
 _BARE_CR = re.compile(r"\r(?!\n)")
 
 
@@ -273,12 +273,13 @@ class StringType(Enum):
     def invalid_sequences(self) -> Collection[str]:
         # https://toml.io/en/v1.0.0#string
         forbidden_in_literal = CONTROL_CHARS - {"\t"}
-        allowed_in_multiline = {"\n", "\r"}
+        # CR stays forbidden in multiline: the value is checked with CRLF
+        # pairs collapsed, so any remaining CR is a lone control character
         return {
             StringType.SLB: (),
             StringType.MLB: (),
             StringType.SLL: forbidden_in_literal | {"'"},
-            StringType.MLL: (forbidden_in_literal | {"'''"}) - allowed_in_multiline,
+            StringType.MLL: (forbidden_in_literal | {"'''"}) - {"\n"},
         }[self]
 
     @property
@@ -2246,11 +2247,10 @@ class String(str, Item):
         value = decode(value)
 
         invalid = type_.invalid_sequences
-        if any(c in value for c in invalid):
+        # collapse CRLF line endings so only a lone CR trips the CR check
+        checked = value.replace("\r\n", "\n")
+        if any(c in checked for c in invalid):
             raise InvalidStringError(value, invalid, type_.value)
-
-        if type_ is StringType.MLL and _BARE_CR.search(value):
-            raise InvalidStringError(value, {"\r"}, type_.value)
 
         escaped = type_.escaped_sequences
         string_value = escape_string(value, escaped) if escape and escaped else value

--- a/tomlkit/items.py
+++ b/tomlkit/items.py
@@ -232,6 +232,12 @@ def item(value: Any, _parent: Item | None = None, _sort_keys: bool = False) -> I
     raise ConvertError(f"Unable to convert an object of {type(value)} to a TOML item")
 
 
+# A carriage return that is not the CR of a CRLF line ending. Inside a multiline
+# string only a raw line feed or a CRLF pair is a valid line ending; a lone CR is
+# a control character. Literal strings cannot escape it, basic strings must.
+_BARE_CR = re.compile(r"\r(?!\n)")
+
+
 class StringType(Enum):
     # Single Line Basic
     SLB = '"'
@@ -2243,8 +2249,14 @@ class String(str, Item):
         if any(c in value for c in invalid):
             raise InvalidStringError(value, invalid, type_.value)
 
+        if type_ is StringType.MLL and _BARE_CR.search(value):
+            raise InvalidStringError(value, {"\r"}, type_.value)
+
         escaped = type_.escaped_sequences
         string_value = escape_string(value, escaped) if escape and escaped else value
+
+        if type_ is StringType.MLB and escape:
+            string_value = _BARE_CR.sub(r"\\r", string_value)
 
         if type_.is_multiline() and string_value[:1] in ("\n", "\r"):
             # A newline immediately following the opening delimiter of a


### PR DESCRIPTION
## Summary

1. `String.from_raw` builds a multiline basic string by escaping every control character except a line feed and a carriage return, so a lone CR (one that is not the CR of a CRLF pair) is written out raw.
2. The multiline literal path drops that same CR from `invalid_sequences`, so a lone CR there is neither escaped nor rejected.
3. Either way `tomlkit.string(value, multiline=True)` and its literal variant emit a document with a raw lone CR, which the tomlkit parser and the stdlib `tomllib` both reject as a control character, so the value stops round-tripping.
4. Escape a lone CR as `\r` for multiline basic strings, and raise `InvalidStringError` for multiline literal strings; LF and CRLF line endings are left untouched.

## Agent Drafting Metadata

- Agent: Claude Code
- Model: Claude (Anthropic)
- Notes: AI tooling helped find the bug and draft the fix and tests. The root cause, the change, and the tests were reviewed and validated by the author before submission (the new cases fail on the unpatched tree, and the full suite passes with the patch), and the author is responsible for what is submitted.
