### PR TITLE
Keep single-line array bracket off a trailing comment line

### DIFF
--- a/tests/test_items.py
+++ b/tests/test_items.py
@@ -529,6 +529,16 @@ def test_array_add_line() -> None:
     )
 
 
+def test_array_add_line_single_line_comment_round_trips() -> None:
+    # A single-line array whose last rendered element is a trailing comment
+    # (from add_line(..., comment=...)) must keep the closing bracket off the
+    # comment line, otherwise the output does not round-trip (GH #580).
+    t = api.array()
+    t.add_line("foo", comment="bar")
+    rendered = t.as_string()
+    assert parse("a = " + rendered)["a"] == ["foo"]
+
+
 def test_array_add_line_multiline_comment_is_rejected() -> None:
     t = api.array()
     with pytest.raises(ValueError, match="line breaks"):

--- a/tomlkit/items.py
+++ b/tomlkit/items.py
@@ -1464,7 +1464,14 @@ class Array(Item, _CustomList):  # type: ignore[type-arg]
 
     def as_string(self) -> str:
         if not self._multiline or not self._value:
-            return f"[{''.join(v.as_string() for v in self._iter_items())}]"
+            rendered = list(self._iter_items())
+            inner = "".join(v.as_string() for v in rendered)
+            if rendered and isinstance(rendered[-1], Comment):
+                # A trailing comment (e.g. from add_line(comment=...)) carries
+                # no newline, so keep the closing bracket off the comment line
+                # to produce parseable output (GH #580).
+                inner += "\n" + self.trivia.indent
+            return f"[{inner}]"
 
         s = "[\n"
         s += "".join(


### PR DESCRIPTION
## Summary

`tomlkit.array().add_line("foo", comment="bar").as_string()` produced `[\n    "foo", # bar]` — the closing `]` landed on the comment line, so the output failed to round-trip (`tomlkit.loads(...)` raised `UnexpectedCharError`). Fixes #580.

`Array.as_string()`'s single-line branch concatenated `]` directly after the joined items. A trailing comment (from `add_line(..., comment=...)`) carries no newline, so the bracket was swallowed by the comment. This moves the bracket onto its own line when the last rendered element is a `Comment`; genuine single-line arrays (`[1, 2, 3]`) and multi-line arrays are byte-for-byte unchanged (the existing `test_array_add_line` assertion still passes).

Note: the issue suggested making `add_line` promote single-line arrays to multiline, but that reformats `add_line(1, 2, 3)` onto separate lines and breaks `test_array_add_line`, so the fix belongs in `as_string`, not `add_line`.

Added a regression test (`test_array_add_line_single_line_comment_round_trips`), verified red before the fix (`UnexpectedCharError`) and green after. `pytest tests/test_items.py` (87 passed) and `ruff format --check` pass locally.

## Agent Drafting Metadata

- Agent: Claude Code
- Model: Claude (Opus)
- Notes: AI-assisted. The fix, the regression test, and this description were reviewed and verified locally by me (red-green cycle plus the full `tests/test_items.py`).
