### PR TITLE
Start a new line before the closing bracket of a commented array

### DIFF
--- a/tests/test_items.py
+++ b/tests/test_items.py
@@ -529,6 +529,35 @@ def test_array_add_line() -> None:
     )
 
 
+def test_array_add_line_trailing_comment_does_not_hide_bracket() -> None:
+    t = api.array()
+    t.add_line("foo", comment="bar")
+
+    assert (
+        t.as_string()
+        == """[
+    "foo", # bar
+]"""
+    )
+
+    doc = api.document()
+    doc.add("array", t)
+    assert parse(doc.as_string())["array"] == ["foo"]
+
+
+def test_array_add_line_trailing_comment_closing_line_is_not_doubled() -> None:
+    t = api.array()
+    t.add_line("foo", comment="bar")
+    t.add_line(indent="")
+
+    assert (
+        t.as_string()
+        == """[
+    "foo", # bar
+]"""
+    )
+
+
 def test_array_add_line_multiline_comment_is_rejected() -> None:
     t = api.array()
     with pytest.raises(ValueError, match="line breaks"):

--- a/tomlkit/items.py
+++ b/tomlkit/items.py
@@ -1464,7 +1464,13 @@ class Array(Item, _CustomList):  # type: ignore[type-arg]
 
     def as_string(self) -> str:
         if not self._multiline or not self._value:
-            return f"[{''.join(v.as_string() for v in self._iter_items())}]"
+            items = list(self._iter_items())
+            body = "".join(v.as_string() for v in items)
+            if items and isinstance(items[-1], Comment):
+                # A comment runs to the end of the line, so the closing bracket
+                # has to start a new one or it would be commented out.
+                body += "\n" + self.trivia.indent
+            return f"[{body}]"
 
         s = "[\n"
         s += "".join(


### PR DESCRIPTION
Fixes #580.

## Problem

```python
>>> array = tomlkit.array()
>>> array.add_line("foo", comment="bar")
>>> print(array.as_string())
[
    "foo", # bar]
```

The closing bracket sits inside the comment, so the output is no longer valid TOML and `tomlkit.loads()` on the containing document raises `UnexpectedCharError`.

## Cause

For a non-multiline array `as_string()` is:

```python
return f"[{''.join(v.as_string() for v in self._iter_items())}]"
```

`add_line(comment=...)` appends a `Comment` as the last item and nothing after it. A comment runs to the end of its line, so anything concatenated after it is commented out — including the bracket.

## Fix

When the last rendered item is a `Comment`, emit a newline and the array's indent before the bracket, mirroring what the multiline branch already does.

The issue suggests instead having `add_line` flip the array to multiline. I went the other way because the multiline branch re-renders with a fixed four-space indent and its own comma placement, which would throw away the layout `add_line` exists to control precisely (`add_line(1, 2, 3)` would become one element per line). This change only adds the separator that is actually missing.

## Scope

Only affects arrays whose rendered items *end* with a comment. A parsed document can't reach that state — the parser has to consume the `]`, and a comment always ends at a newline, so a parsed array's last item is whitespace. So this is confined to arrays built through the API, and the existing `test_array_add_line` (which ends with `add_line(indent="")`) is unchanged, as is byte-for-byte round-tripping of parsed documents.

## Tests

- `test_array_add_line_trailing_comment_does_not_hide_bracket` — the reported case, plus a re-parse of the containing document.
- `test_array_add_line_trailing_comment_closing_line_is_not_doubled` — calling `add_line(indent="")` after a comment still produces exactly one closing line, not two.

Full suite passes (1053 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)