### PR TITLE
Accept a table extending an out-of-order child of an out-of-order table

### DIFF
--- a/tests/test_toml_document.py
+++ b/tests/test_toml_document.py
@@ -643,6 +643,64 @@ def test_valid_out_of_order_independent_tables() -> None:
     assert doc.as_string() == "[a]\nx=1\n[zz]\n[a.b]\nc=1\n"
 
 
+def test_extend_out_of_order_child_of_out_of_order_table() -> None:
+    # https://github.com/python-poetry/tomlkit/issues/571
+    # `lint` is itself out of order inside `ruff` ([tool.ruff.lint.a] then
+    # [tool.ruff.lint]), so validating the later [tool.ruff.lint.b] fragment
+    # looks `lint` up and gets an OutOfOrderTableProxy back rather than a
+    # Table. That must not be read as a type change.
+    content = """\
+[tool.ruff]
+[tool.ruff.lint.a]
+[tool.ruff.lint]
+[[tool.poetry.source]]
+[tool.ruff.lint.b]
+"""
+    doc = parse(content)
+
+    assert doc.unwrap() == {
+        "tool": {
+            "ruff": {"lint": {"a": {}, "b": {}}},
+            "poetry": {"source": [{}]},
+        }
+    }
+    assert doc.as_string() == content
+
+
+def test_reject_duplicate_child_of_out_of_order_table() -> None:
+    # The counterpart of the above: the last header redefines the concrete
+    # [tool.ruff.lint] table, which is invalid and must still be rejected
+    # even though `lint` is reached through a proxy.
+    with pytest.raises(ParseError):
+        parse(
+            "[tool.ruff]\n"
+            "[tool.ruff.lint.a]\n"
+            "[tool.ruff.lint]\n"
+            "[[tool.poetry.source]]\n"
+            "[tool.ruff.lint]\n"
+        )
+
+
+def test_extend_out_of_order_child_at_depth() -> None:
+    content = """\
+[t.r]
+[t.r.l.a]
+[t.r.l]
+[z]
+[t.r.l.b.c]
+[q]
+[t.r.l.b.d]
+"""
+    doc = parse(content)
+
+    assert doc.unwrap() == {
+        "t": {"r": {"l": {"a": {}, "b": {"c": {}, "d": {}}}}},
+        "z": {},
+        "q": {},
+    }
+    assert doc.as_string() == content
+
+
 def test_set_value_on_out_of_order_table_with_empty_concrete_part() -> None:
     # A super table defined after its sub-table (the "defining a super-table
     # afterward is ok" spec example) leaves an empty concrete `[x]` part.

--- a/tomlkit/container.py
+++ b/tomlkit/container.py
@@ -418,12 +418,34 @@ class Container(_CustomDict):  # type: ignore[type-arg]
         return self
 
     def _validate_table_candidate(self, current: Table, candidate: Table) -> None:
-        for k, v in candidate.value.body:
+        self._validate_container_candidate(current.value, candidate.value)
+
+    def _validate_container_candidate(
+        self, current: Container, candidate: Container
+    ) -> None:
+        for k, v in candidate.body:
             if k is None:
                 continue
 
-            if k in current.value._map:
-                existing = current.value.item(k)
+            if k in current._map:
+                existing = current.item(k)
+                if isinstance(existing, OutOfOrderTableProxy):
+                    # `k` is itself already split across out-of-order parts, so
+                    # `item()` hands back a proxy rather than a Table. Compare
+                    # against the merged view the proxy holds instead of
+                    # treating it as a non-table value.
+                    if not isinstance(v, Table):
+                        raise KeyAlreadyPresent(k)
+                    if k.is_dotted():
+                        raise TOMLKitError("Redefinition of an existing table")
+                    if not v.is_super_table() and any(
+                        not part.is_super_table() for part in existing._tables
+                    ):
+                        raise KeyAlreadyPresent(k)
+                    self._validate_container_candidate(
+                        existing._internal_container, v.value
+                    )
+                    continue
                 if isinstance(existing, (Table, AoT)) != isinstance(v, (Table, AoT)):
                     raise KeyAlreadyPresent(k)
                 if k.is_dotted():
@@ -435,20 +457,20 @@ class Container(_CustomDict):  # type: ignore[type-arg]
                         raise KeyAlreadyPresent(k)
                     # One side is still an implicit/super table, so a duplicate
                     # (if any) is nested deeper - keep checking the subtree.
-                    self._validate_table_candidate(existing, v)
+                    self._validate_container_candidate(existing.value, v.value)
                 continue
 
             if not k.is_dotted():
                 # Even when the candidate key itself is not dotted, an
                 # existing dotted key may already use it as a prefix —
                 # e.g.  [a] b.c=1 then [a.b] d=2  (b prefixes b.c).
-                for existing_key in current.value._map:
+                for existing_key in current._map:
                     if existing_key.is_dotted() and next(iter(existing_key)) == k:
                         raise TOMLKitError("Redefinition of an existing table")
                 continue
 
             head = next(iter(k))
-            if head in current.value._map:
+            if head in current._map:
                 raise TOMLKitError("Redefinition of an existing table")
 
     def _raw_append(self, key: Key | None, item: Item) -> None:


### PR DESCRIPTION
Fixes #571.

## Problem

```toml
[tool.ruff]
[tool.ruff.lint.a]
[tool.ruff.lint]
[[tool.poetry.source]]
[tool.ruff.lint.b]
```

```
tomlkit.exceptions.ParseError: Key "lint" already exists. at line 5 col 0
```

`tomllib` and tomlkit 0.13.3 / 0.14.0 / 0.15.0 all accept this; 0.15.1 and `master` reject it.

## Cause

`tool` is out of order at the top level, so the last header extends an existing concrete `tool` fragment with a super table, which goes through `Container._validate_table_candidate`. That looks each candidate key up with `Container.item()`:

```python
existing = current.value.item(k)
if isinstance(existing, (Table, AoT)) != isinstance(v, (Table, AoT)):
    raise KeyAlreadyPresent(k)
```

`lint` is *itself* split across two parts of `ruff` — the implicit one from `[tool.ruff.lint.a]` and the concrete `[tool.ruff.lint]`. `item()` therefore returns an `OutOfOrderTableProxy`, which is neither a `Table` nor an `AoT`, so the guard reads it as "a table is being replaced by a plain value" and raises.

The intervening `[[tool.poetry.source]]` matters only because without it the parser keeps all the `tool` headers in one fragment and this validation path is never reached. Any unrelated header reproduces it.

## Fix

Give the proxy its own branch, comparing against the merged view its internal container already holds. The duplicate-definition rule is preserved by asking whether any of the proxy's parts is concrete, so a genuine redefinition still raises.

The recursion now threads `Container`s instead of `Table`s — every check in the function already went through `.value`, so this is a rename plus the new branch, and it is what lets the proxy's internal container be passed down.

## Tests

- `test_extend_out_of_order_child_of_out_of_order_table` — the reported document parses, unwraps to the same shape `tomllib` produces, and round-trips byte-for-byte.
- `test_reject_duplicate_child_of_out_of_order_table` — same shape but the last header repeats `[tool.ruff.lint]`; still a `ParseError`.
- `test_extend_out_of_order_child_at_depth` — two more levels down, with two intervening headers.

I also diffed tomlkit against `tomllib` over the surrounding cases (duplicate `[a]`, `[a.b]` twice across a split, a value/table conflict `[a] x=1 … [a.x]`, dotted-key redefinition `[a] b.c=1 … [a.b]`): accept/reject now agrees with `tomllib` on all of them.

Full suite passes (1054 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)