### PR TITLE
Merge an out-of-order fragment that extends an AoT element

### DIFF
--- a/tests/test_toml_document.py
+++ b/tests/test_toml_document.py
@@ -688,6 +688,52 @@ y = 2
     assert 'matcher = "patched"' in doc.as_string()
 
 
+def test_out_of_order_table_merges_aot_element_extension() -> None:
+    # https://github.com/python-poetry/tomlkit/issues/577
+    # `[[y.a.c]]` extends the last element of the existing `y.a` array rather
+    # than adding one, so the second `a` fragment reaches the proxy as an
+    # implicit super table and not as another AoT.
+    content = """\
+[[y.a]]
+n = 1
+
+[b.d.x]
+
+[[y.a.c]]
+m = 2
+"""
+    doc = parse(content)
+    assert doc.as_string() == content
+
+    assert doc.unwrap() == {
+        "y": {"a": [{"n": 1, "c": [{"m": 2}]}]},
+        "b": {"d": {"x": {}}},
+    }
+    assert doc["y"]["a"][0]["c"][0]["m"] == 2
+
+
+def test_out_of_order_table_extends_last_of_several_aot_elements() -> None:
+    content = """\
+[[y.a]]
+n = 1
+
+[[y.a]]
+n = 2
+
+[b.d.x]
+
+[[y.a.c]]
+m = 3
+"""
+    doc = parse(content)
+    assert doc.as_string() == content
+
+    assert doc.unwrap() == {
+        "y": {"a": [{"n": 1}, {"n": 2, "c": [{"m": 3}]}]},
+        "b": {"d": {"x": {}}},
+    }
+
+
 def test_out_of_order_table_merges_three_aot_fragments() -> None:
     # An AoT split across more than two out-of-order parts merges into a single
     # AoT: each later fragment is appended to the growing element list, so the

--- a/tomlkit/container.py
+++ b/tomlkit/container.py
@@ -1123,7 +1123,9 @@ class OutOfOrderTableProxy(_CustomDict):  # type: ignore[type-arg]
         Returns the merged ``AoT``, or ``None`` if this is not such a fragment.
         """
         internal = self._internal_container
-        if key is None or not isinstance(item, AoT) or key not in internal._map:
+        if key is None or not isinstance(item, (AoT, Table)):
+            return None
+        if key not in internal._map:
             return None
         idx = internal._map[key]
         if isinstance(idx, tuple):
@@ -1137,7 +1139,21 @@ class OutOfOrderTableProxy(_CustomDict):  # type: ignore[type-arg]
         if not isinstance(existing, AoT):
             return None
 
-        merged = AoT([*existing.body, *item.body], parsed=True)
+        if isinstance(item, AoT):
+            elements = [*existing.body, *item.body]
+        else:
+            # The later part extends the array's last element instead of adding
+            # one: `[[y.a]]` followed by `[[y.a.c]]` reaches here with `a` as an
+            # implicit super table holding `c`. Copy the element before merging
+            # so the fragment the document renders from is left alone.
+            if not item.is_super_table() or not existing.body:
+                return None
+            last = copy.deepcopy(existing.body[-1])
+            for k, v in item.value.body:
+                last.value.append(k, copy.deepcopy(v))
+            elements = [*existing.body[:-1], last]
+
+        merged = AoT(elements, parsed=True)
         internal._body[idx] = (internal._body[idx][0], merged)
         dict.__setitem__(internal, key.key, merged.value)
         return merged


### PR DESCRIPTION
Fixes #577.

## Problem

```python
content = """\
[[y.a]]
[b.d.x]
[[y.a.c]]
"""
doc = parse(content)
assert doc.as_string() == content   # passes
doc.unwrap()                        # KeyAlreadyPresent: Key "a" already exists
```

`tomllib` reads this as `{"y": {"a": [{"c": [{}]}]}, "b": {"d": {"x": {}}}}`. Parsing and rendering are fine; only the read path fails.

## Cause

`[b.d.x]` splits `y`, so reading it builds an `OutOfOrderTableProxy` over the two `y` fragments. The final header extends the **last element** of the existing `y.a` array rather than appending a new element, so the second `a` fragment arrives at the proxy as an implicit super table holding `c` — not as another `AoT`.

`_merge_aot_fragment` only handles `AoT` + `AoT`. It returned `None` for the super-table shape, the caller fell through to `_raw_append`, and that refused `a` as a duplicate key.

## Fix

Handle the super-table shape in the same place: copy the array's last element, merge the fragment's body into the copy, and hand back a new `AoT`. Copying is what keeps the fragments the document renders from untouched — the same reason the existing `AoT` + `AoT` path builds a new `AoT` instead of mutating one.

The guard stays narrow: only a super table (never a concrete `[y.a]` redefinition) and only when the array actually has an element, so genuine duplicates still raise.

## Tests

- `test_out_of_order_table_merges_aot_element_extension` — the reported document, with values on both sides, checking round-trip, `unwrap()` against the `tomllib` shape, and indexed access.
- `test_out_of_order_table_extends_last_of_several_aot_elements` — two elements before the split, confirming the extension lands on the last one only.

I also checked the neighbouring shapes against `tomllib` (a plain out-of-order AoT split, `[y.a.c]` as a plain table rather than an AoT, and two `[[y.a.c]]` headers separated by another table); all agree.

Full suite passes (1053 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)