### PR TITLE
fix: close Array.add_line output before the closing bracket

### DIFF
--- a/tests/test_items.py
+++ b/tests/test_items.py
@@ -529,6 +529,19 @@ def test_array_add_line() -> None:
     )
 
 
+def test_array_add_line_closes_the_last_line() -> None:
+    t = api.array()
+    t.add_line("foo", comment="bar")
+
+    assert (
+        t.as_string()
+        == """[
+    \"foo\", # bar
+]"""
+    )
+    assert parse(f"array = {t.as_string()}").unwrap() == {"array": ["foo"]}
+
+
 def test_array_add_line_multiline_comment_is_rejected() -> None:
     t = api.array()
     with pytest.raises(ValueError, match="line breaks"):

--- a/tomlkit/items.py
+++ b/tomlkit/items.py
@@ -1547,6 +1547,15 @@ class Array(Item, _CustomList):  # type: ignore[type-arg]
             new_values.append(
                 Comment(Trivia(indent=indent, comment=f"# {comment}", trail=""))
             )
+
+        if (
+            self._value
+            and self._value[-1].is_whitespace()
+            and self._value[-1].indent is not None
+            and self._value[-1].indent.s == "\n"
+        ):
+            self._value.pop()
+
         list.extend(self, data_values)
         if len(self._value) > 0:
             last_item = self._value[-1]
@@ -1566,6 +1575,8 @@ class Array(Item, _CustomList):  # type: ignore[type-arg]
                 self._value.extend(self._group_values(new_values))
         else:
             self._value.extend(self._group_values(new_values))
+        if newline and (items or comment):
+            self._value.extend(self._group_values([Whitespace("\n")]))
         self._reindex()
 
     def clear(self) -> None:


### PR DESCRIPTION
## Summary
- preserve a trailing line break for content added with `Array.add_line()`
- avoid emitting a comment immediately before the closing `]`, which produces invalid TOML
- add a regression test that parses the generated output

Fixes #580

## Validation
- `poetry run pytest tests/test_items.py -k array_add_line -q`
- `poetry run pytest -q tests` (1052 passed)
- `uvx ruff@0.15.21 check tomlkit/items.py tests/test_items.py`
- `poetry run python -m compileall -q tomlkit tests/test_items.py`

`poetry run mypy tomlkit/items.py tests/test_items.py` still reports the pre-existing `tomlkit/items.py:2172` annotation error.

## Disclosure
AI assistance was used while preparing this contribution; I reviewed the change and ran the validation above.