### PR TITLE
Accept uppercase E exponent after a leading-zero mantissa

### DIFF
--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -8,6 +8,7 @@ from tomlkit.exceptions import InvalidNumberError
 from tomlkit.exceptions import InvalidUnicodeValueError
 from tomlkit.exceptions import ParseError
 from tomlkit.exceptions import UnexpectedCharError
+from tomlkit.items import Float
 from tomlkit.items import Integer
 from tomlkit.items import StringType
 from tomlkit.parser import Parser
@@ -235,3 +236,13 @@ def test_parser_rejects_overlong_decimal_integer() -> None:
     # the value just under the limit is still a normal integer
     value = Parser("a = " + "9" * 4300).parse()["a"]
     assert isinstance(value, Integer)
+
+
+def test_parser_accepts_uppercase_exponent_after_leading_zero() -> None:
+    # Both "e" and "E" are valid exponent markers. A leading-zero mantissa was
+    # only exempted from the "no leading zeros" rule for lowercase "0e", so
+    # "0E2" and its signed forms were wrongly rejected as an invalid number.
+    for raw in ("0E2", "0E+2", "0E-2", "+0E2", "-0E2"):
+        value = Parser(f"a = {raw}").parse()["a"]
+        assert isinstance(value, Float)
+        assert value == float(raw)

--- a/tomlkit/parser.py
+++ b/tomlkit/parser.py
@@ -749,7 +749,10 @@ class Parser:
             raw = raw[1:]
 
         if len(raw) > 1 and (
-            (raw.startswith("0") and not raw.startswith(("0.", "0o", "0x", "0b", "0e")))
+            (
+                raw.startswith("0")
+                and not raw.startswith(("0.", "0o", "0x", "0b", "0e", "0E"))
+            )
             or (sign and raw.startswith("."))
         ):
             return None


### PR DESCRIPTION
`tomlkit` rejects the float `0E2`, which is valid TOML. Both `e` and `E` are allowed exponent markers, and `tomlkit` already parses the lowercase form:

```python
import tomlkit

tomlkit.parse("x = 0e2")   # ok, 0.0
tomlkit.parse("x = 0E2")   # tomlkit.exceptions.InvalidNumberError
```

The signed forms (`+0E2`, `-0E2`, `0E+2`) fail the same way, and `tomllib` from the standard library accepts all of them. The `valid/float/exponent-upper.toml` case in the toml-test suite trips over this on its `+0E2` line.

The cause is the "no leading zeros" guard in `_parse_number`: a mantissa beginning with `0` is exempted only when it is followed by `.`, `o`, `x`, `b`, or a lowercase `e`, so `0E...` falls through to the leading-zero rejection. Adding `0E` to the exempted prefixes fixes it. I covered the plain and signed forms in `test_parser.py`.
