### PR TITLE
Fix three toml-test 1.1.0 compliance gaps

### DIFF
--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -246,3 +246,14 @@ def test_parser_accepts_uppercase_exponent_after_leading_zero() -> None:
         value = Parser(f"a = {raw}").parse()["a"]
         assert isinstance(value, Float)
         assert value == float(raw)
+
+
+def test_bom_only_document_keeps_bom_at_start_after_mutation() -> None:
+    # A document that is just a leading BOM has no body item to attach the
+    # BOM to, so it's stored as its own Whitespace entry. If that entry isn't
+    # marked fixed=True, Container's insertion logic treats it as discardable
+    # filler and puts newly added keys before it, moving the BOM off the
+    # front of the file.
+    doc = Parser("\ufeff").parse()
+    doc["a"] = 1
+    assert doc.as_string() == "\ufeffa = 1\n"

--- a/tests/test_toml_tests.py
+++ b/tests/test_toml_tests.py
@@ -16,6 +16,58 @@ from tomlkit.exceptions import TOMLKitError
 TESTS_ROOT = os.path.join(os.path.dirname(__file__), "toml-test", "tests")
 FILES_LIST = os.path.join(TESTS_ROOT, "files-toml-1.1.0")
 
+# Cases added upstream (toml-test) that tomlkit does not yet handle correctly.
+# Each reason cites the toml-test commit that introduced the case and its
+# upstream issue, so these can be found again once the underlying bug is fixed.
+KNOWN_FAILURES = {
+    "valid/utf8-bom-01": (
+        "leading UTF-8 BOM is not stripped before parsing "
+        "(toml-test 542746b, BurntSushi/toml-test#199)"
+    ),
+    "valid/utf8-bom-02": (
+        "leading UTF-8 BOM is not stripped before parsing "
+        "(toml-test 542746b, BurntSushi/toml-test#199)"
+    ),
+    "invalid/control/linetab-number-01": (
+        "trailing \\x0b (vertical tab) after an integer is not rejected "
+        "(toml-test 4f76d84, BurntSushi/toml-test#195)"
+    ),
+    "invalid/control/linetab-number-02": (
+        "trailing \\x0b (vertical tab) after a float is not rejected "
+        "(toml-test 4f76d84, BurntSushi/toml-test#195)"
+    ),
+    "invalid/control/linetab-number-03": (
+        "trailing \\x0b (vertical tab) after a hex integer is not rejected "
+        "(toml-test 4f76d84, BurntSushi/toml-test#195)"
+    ),
+    "invalid/float/arabic-zero-01": (
+        "Arabic-Indic digit zero (٠) is accepted as a fraction digit "
+        "(toml-test d736b6f, BurntSushi/toml-test#196)"
+    ),
+    "invalid/float/arabic-zero-03": (
+        "Arabic-Indic digit zero (٠) is accepted in an exponent "
+        "(toml-test d736b6f, BurntSushi/toml-test#196)"
+    ),
+    "invalid/float/arabic-zero-04": (
+        "Arabic-Indic digit zero (٠) is accepted as a signed float value "
+        "(toml-test d736b6f, BurntSushi/toml-test#196)"
+    ),
+    "invalid/integer/arabic-zero-01": (
+        "Arabic-Indic digit zero (٠) is accepted as a trailing integer digit "
+        "(toml-test d736b6f, BurntSushi/toml-test#196)"
+    ),
+    "invalid/integer/arabic-zero-02": (
+        "Arabic-Indic digit zero (٠) is accepted after an underscore digit "
+        "separator (toml-test d736b6f, BurntSushi/toml-test#196)"
+    ),
+}
+
+
+def _param(case_id: str, value: Any) -> Any:
+    reason = KNOWN_FAILURES.get(case_id)
+    marks = [pytest.mark.xfail(reason=reason, strict=True)] if reason else []
+    return pytest.param(value, id=case_id, marks=marks)
+
 
 def to_bool(s: str) -> bool:
     assert s in ["true", "false"]
@@ -56,20 +108,10 @@ def _load_case_list() -> list[str]:
         return [line.strip() for line in f if line.strip()]
 
 
-def _build_cases() -> tuple[
-    list[dict[str, str]],
-    list[str],
-    list[dict[str, str]],
-    list[str],
-    list[str],
-    list[str],
-]:
+def _build_cases() -> tuple[list[Any], list[Any], list[Any]]:
     valid_cases = []
-    valid_ids = []
     invalid_decode_cases = []
-    invalid_decode_ids = []
     invalid_encode_cases = []
-    invalid_encode_ids = []
 
     for relpath in _load_case_list():
         full_path = os.path.join(TESTS_ROOT, relpath)
@@ -79,8 +121,7 @@ def _build_cases() -> tuple[
         case_id = relpath.rsplit(".", 1)[0]
 
         if relpath.startswith("invalid/encoding/"):
-            invalid_encode_cases.append(full_path)
-            invalid_encode_ids.append(case_id)
+            invalid_encode_cases.append(_param(case_id, full_path))
         elif relpath.startswith("valid/"):
             with open(full_path, encoding="utf-8", newline="") as f:
                 toml_content = f.read()
@@ -89,36 +130,22 @@ def _build_cases() -> tuple[
             with open(json_path, encoding="utf-8") as f:
                 json_content = f.read()
 
-            valid_cases.append({"toml": toml_content, "json": json_content})
-            valid_ids.append(case_id)
+            valid_cases.append(
+                _param(case_id, {"toml": toml_content, "json": json_content})
+            )
         elif relpath.startswith("invalid/"):
             with open(full_path, encoding="utf-8", newline="") as f:
                 toml_content = f.read()
 
-            invalid_decode_cases.append({"toml": toml_content})
-            invalid_decode_ids.append(case_id)
+            invalid_decode_cases.append(_param(case_id, {"toml": toml_content}))
 
-    return (
-        valid_cases,
-        valid_ids,
-        invalid_decode_cases,
-        invalid_decode_ids,
-        invalid_encode_cases,
-        invalid_encode_ids,
-    )
+    return valid_cases, invalid_decode_cases, invalid_encode_cases
 
 
-(
-    VALID_CASES,
-    VALID_IDS,
-    INVALID_DECODE_CASES,
-    INVALID_DECODE_IDS,
-    INVALID_ENCODE_CASES,
-    INVALID_ENCODE_IDS,
-) = _build_cases()
+VALID_CASES, INVALID_DECODE_CASES, INVALID_ENCODE_CASES = _build_cases()
 
 
-@pytest.mark.parametrize("toml11_valid_case", VALID_CASES, ids=VALID_IDS)
+@pytest.mark.parametrize("toml11_valid_case", VALID_CASES)
 def test_valid_decode(toml11_valid_case: dict[str, str]) -> None:
     json_val = untag(json.loads(toml11_valid_case["json"]))
     toml_val = parse(toml11_valid_case["toml"])
@@ -127,17 +154,13 @@ def test_valid_decode(toml11_valid_case: dict[str, str]) -> None:
     assert toml_val.as_string() == toml11_valid_case["toml"]
 
 
-@pytest.mark.parametrize(
-    "toml11_invalid_decode_case", INVALID_DECODE_CASES, ids=INVALID_DECODE_IDS
-)
+@pytest.mark.parametrize("toml11_invalid_decode_case", INVALID_DECODE_CASES)
 def test_invalid_decode(toml11_invalid_decode_case: dict[str, str]) -> None:
     with pytest.raises(TOMLKitError):
         parse(toml11_invalid_decode_case["toml"])
 
 
-@pytest.mark.parametrize(
-    "toml11_invalid_encode_case", INVALID_ENCODE_CASES, ids=INVALID_ENCODE_IDS
-)
+@pytest.mark.parametrize("toml11_invalid_encode_case", INVALID_ENCODE_CASES)
 def test_invalid_encode(toml11_invalid_encode_case: str) -> None:
     with open(toml11_invalid_encode_case, encoding="utf-8") as f:
         with pytest.raises((TOMLKitError, UnicodeDecodeError)):

--- a/tests/test_toml_tests.py
+++ b/tests/test_toml_tests.py
@@ -20,14 +20,6 @@ FILES_LIST = os.path.join(TESTS_ROOT, "files-toml-1.1.0")
 # Each reason cites the toml-test commit that introduced the case and its
 # upstream issue, so these can be found again once the underlying bug is fixed.
 KNOWN_FAILURES = {
-    "valid/utf8-bom-01": (
-        "leading UTF-8 BOM is not stripped before parsing "
-        "(toml-test 542746b, BurntSushi/toml-test#199)"
-    ),
-    "valid/utf8-bom-02": (
-        "leading UTF-8 BOM is not stripped before parsing "
-        "(toml-test 542746b, BurntSushi/toml-test#199)"
-    ),
 }
 
 

--- a/tests/test_toml_tests.py
+++ b/tests/test_toml_tests.py
@@ -28,26 +28,6 @@ KNOWN_FAILURES = {
         "leading UTF-8 BOM is not stripped before parsing "
         "(toml-test 542746b, BurntSushi/toml-test#199)"
     ),
-    "invalid/float/arabic-zero-01": (
-        "Arabic-Indic digit zero (٠) is accepted as a fraction digit "
-        "(toml-test d736b6f, BurntSushi/toml-test#196)"
-    ),
-    "invalid/float/arabic-zero-03": (
-        "Arabic-Indic digit zero (٠) is accepted in an exponent "
-        "(toml-test d736b6f, BurntSushi/toml-test#196)"
-    ),
-    "invalid/float/arabic-zero-04": (
-        "Arabic-Indic digit zero (٠) is accepted as a signed float value "
-        "(toml-test d736b6f, BurntSushi/toml-test#196)"
-    ),
-    "invalid/integer/arabic-zero-01": (
-        "Arabic-Indic digit zero (٠) is accepted as a trailing integer digit "
-        "(toml-test d736b6f, BurntSushi/toml-test#196)"
-    ),
-    "invalid/integer/arabic-zero-02": (
-        "Arabic-Indic digit zero (٠) is accepted after an underscore digit "
-        "separator (toml-test d736b6f, BurntSushi/toml-test#196)"
-    ),
 }
 
 

--- a/tests/test_toml_tests.py
+++ b/tests/test_toml_tests.py
@@ -28,18 +28,6 @@ KNOWN_FAILURES = {
         "leading UTF-8 BOM is not stripped before parsing "
         "(toml-test 542746b, BurntSushi/toml-test#199)"
     ),
-    "invalid/control/linetab-number-01": (
-        "trailing \\x0b (vertical tab) after an integer is not rejected "
-        "(toml-test 4f76d84, BurntSushi/toml-test#195)"
-    ),
-    "invalid/control/linetab-number-02": (
-        "trailing \\x0b (vertical tab) after a float is not rejected "
-        "(toml-test 4f76d84, BurntSushi/toml-test#195)"
-    ),
-    "invalid/control/linetab-number-03": (
-        "trailing \\x0b (vertical tab) after a hex integer is not rejected "
-        "(toml-test 4f76d84, BurntSushi/toml-test#195)"
-    ),
     "invalid/float/arabic-zero-01": (
         "Arabic-Indic digit zero (٠) is accepted as a fraction digit "
         "(toml-test d736b6f, BurntSushi/toml-test#196)"

--- a/tests/test_toml_tests.py
+++ b/tests/test_toml_tests.py
@@ -79,9 +79,7 @@ def _build_cases() -> tuple[list[Any], list[Any], list[Any]]:
                 json_content = f.read()
 
             valid_cases.append(
-                pytest.param(
-                    {"toml": toml_content, "json": json_content}, id=case_id
-                )
+                pytest.param({"toml": toml_content, "json": json_content}, id=case_id)
             )
         elif relpath.startswith("invalid/"):
             with open(full_path, encoding="utf-8", newline="") as f:

--- a/tests/test_toml_tests.py
+++ b/tests/test_toml_tests.py
@@ -16,18 +16,6 @@ from tomlkit.exceptions import TOMLKitError
 TESTS_ROOT = os.path.join(os.path.dirname(__file__), "toml-test", "tests")
 FILES_LIST = os.path.join(TESTS_ROOT, "files-toml-1.1.0")
 
-# Cases added upstream (toml-test) that tomlkit does not yet handle correctly.
-# Each reason cites the toml-test commit that introduced the case and its
-# upstream issue, so these can be found again once the underlying bug is fixed.
-KNOWN_FAILURES = {
-}
-
-
-def _param(case_id: str, value: Any) -> Any:
-    reason = KNOWN_FAILURES.get(case_id)
-    marks = [pytest.mark.xfail(reason=reason, strict=True)] if reason else []
-    return pytest.param(value, id=case_id, marks=marks)
-
 
 def to_bool(s: str) -> bool:
     assert s in ["true", "false"]
@@ -81,7 +69,7 @@ def _build_cases() -> tuple[list[Any], list[Any], list[Any]]:
         case_id = relpath.rsplit(".", 1)[0]
 
         if relpath.startswith("invalid/encoding/"):
-            invalid_encode_cases.append(_param(case_id, full_path))
+            invalid_encode_cases.append(pytest.param(full_path, id=case_id))
         elif relpath.startswith("valid/"):
             with open(full_path, encoding="utf-8", newline="") as f:
                 toml_content = f.read()
@@ -91,13 +79,17 @@ def _build_cases() -> tuple[list[Any], list[Any], list[Any]]:
                 json_content = f.read()
 
             valid_cases.append(
-                _param(case_id, {"toml": toml_content, "json": json_content})
+                pytest.param(
+                    {"toml": toml_content, "json": json_content}, id=case_id
+                )
             )
         elif relpath.startswith("invalid/"):
             with open(full_path, encoding="utf-8", newline="") as f:
                 toml_content = f.read()
 
-            invalid_decode_cases.append(_param(case_id, {"toml": toml_content}))
+            invalid_decode_cases.append(
+                pytest.param({"toml": toml_content}, id=case_id)
+            )
 
     return valid_cases, invalid_decode_cases, invalid_encode_cases
 

--- a/tomlkit/parser.py
+++ b/tomlkit/parser.py
@@ -742,6 +742,12 @@ class Parser:
         return InlineTable(elems, Trivia())
 
     def _parse_number(self, raw: str, trivia: Trivia) -> Item | None:
+        # Reject non-ASCII digit characters (e.g. Arabic-Indic zero, ٠):
+        # int()/float() accept any Unicode decimal digit, but TOML numbers
+        # are ASCII-only.
+        if not raw.isascii():
+            return None
+
         # Leading zeros are not allowed
         sign = ""
         if raw.startswith(("+", "-")):

--- a/tomlkit/parser.py
+++ b/tomlkit/parser.py
@@ -761,7 +761,7 @@ class Parser:
         return InlineTable(elems, Trivia())
 
     def _parse_number(self, raw: str, trivia: Trivia) -> Item | None:
-        # Reject non-ASCII digit characters (e.g. Arabic-Indic zero, ٠):
+        # Reject non-ASCII digit characters (e.g. Arabic-Indic zero, U+0660):
         # int()/float() accept any Unicode decimal digit, but TOML numbers
         # are ASCII-only.
         if not raw.isascii():

--- a/tomlkit/parser.py
+++ b/tomlkit/parser.py
@@ -56,6 +56,7 @@ CTRL_J = 0x0A  # Line feed
 CTRL_M = 0x0D  # Carriage return
 CTRL_CHAR_LIMIT = 0x1F
 CHR_DEL = 0x7F
+BOM = "\ufeff"
 
 # TOML character classes (formerly the `TOMLChar` constants), as frozensets for
 # O(1) membership tests; also the stop-sets for the Source.advance_while /
@@ -102,7 +103,14 @@ class Parser:
 
     def __init__(self, string: str | bytes) -> None:
         # Input to parse
-        self._src = Source(decode(string))
+        decoded = decode(string)
+        # A single leading BOM is allowed and ignored for parsing purposes, but
+        # it is re-attached to the first item's indent below so that dumping
+        # the parsed document reproduces the original text.
+        self._leading_bom = decoded[:1] == BOM
+        if self._leading_bom:
+            decoded = decoded[1:]
+        self._src = Source(decoded)
 
         self._aot_stack: list[Key] = []
         self._nesting_depth = 0
@@ -209,6 +217,13 @@ class Parser:
                 raise self.parse_error(ParseError, str(e)) from e
 
         body.parsing(False)
+
+        if self._leading_bom:
+            if body.body:
+                first_item = body.body[0][1]
+                first_item.trivia.indent = BOM + first_item.trivia.indent
+            else:
+                body.append(None, Whitespace(BOM))
 
         return body
 

--- a/tomlkit/parser.py
+++ b/tomlkit/parser.py
@@ -223,7 +223,11 @@ class Parser:
                 first_item = body.body[0][1]
                 first_item.trivia.indent = BOM + first_item.trivia.indent
             else:
-                body.append(None, Whitespace(BOM))
+                # fixed=True: an ordinary (non-fixed) Whitespace is treated as
+                # discardable filler by Container's insertion logic, so a plain
+                # Whitespace(BOM) here would let new top-level items get
+                # inserted before it, moving the BOM away from the start.
+                body.append(None, Whitespace(BOM, fixed=True))
 
         return body
 

--- a/tomlkit/parser.py
+++ b/tomlkit/parser.py
@@ -783,6 +783,12 @@ class Parser:
         ):
             return None
 
+        # int()/float() silently strip leading/trailing whitespace-like chars
+        # (e.g. \x0b), which would otherwise let a stray control char right
+        # after a number token slip through unnoticed.
+        if any(c.isspace() for c in clean):
+            return None
+
         try:
             return Integer(int(sign + clean, base), trivia, sign + raw)
         except ValueError:


### PR DESCRIPTION
## Summary
Updates the `tests/toml-test` submodule to the latest toml-test corpus and fixes three parsing bugs it surfaced:

- Numbers with an embedded/trailing whitespace-like control char (e.g. vertical tab) were wrongly accepted.
- Non-ASCII (Arabic-Indic) digit characters were wrongly accepted in numeric literals.
- A leading Unicode BOM was not stripped before parsing.

Also fixes an additional edge case found while manually verifying the BOM fix: mutating a document that consists only of a leading BOM (no other content) moved the BOM to the end of the file instead of keeping it at the start.

## Test plan
- [x] `pytest` passes locally (1085 passed, 0 xfailed)
- [x] Full toml-test 1.1.0 corpus passes with no `xfail` markers remaining