### PR TITLE
Render the header of emptied super tables created from dotted keys

### DIFF
--- a/tests/test_toml_document.py
+++ b/tests/test_toml_document.py
@@ -1343,6 +1343,17 @@ def test_remove_item_from_super_table() -> None:
     assert doc.as_string() == dedent(expected)
 
 
+def test_pop_leaf_of_dotted_key_keeps_super_table_in_output() -> None:
+    content = "x.y.z = 1\n"
+    doc = parse(content)
+    doc["x"]["y"].pop("z")
+    expected = """\
+[x.y]
+"""
+    assert doc.as_string() == dedent(expected)
+    assert parse(doc.as_string()) == doc
+
+
 def test_nested_table_update_display_name() -> None:
     content = """\
     [parent]

--- a/tomlkit/container.py
+++ b/tomlkit/container.py
@@ -686,6 +686,13 @@ class Container(_CustomDict):  # type: ignore[type-arg]
                 )
                 and not key.is_dotted()
             )
+            # An emptied table materialized from a dotted key would render
+            # nothing at all and silently disappear from the output; emit its
+            # explicit header instead.
+            or (
+                key.is_dotted()
+                and all(isinstance(v, (Whitespace, Null)) for _, v in table.value.body)
+            )
         ):
             open_, close = "[", "]"
             if table.is_aot_element():


### PR DESCRIPTION
## Summary

Popping the last key of a dotted-key chain (`x.y.z = 1`) left the still-present parent path rendering as blank whitespace instead of an explicit header, so `parse(dumps(doc))` silently lost the empty `x.y` structure.

`_render_table` now emits the explicit header when a super table materialized from a dotted key has no renderable content left, so the structure survives the round trip. Out-of-order table parts, arrays of tables and whole-key deletions are untouched: this fixes only the super-table half of #553 and is independent of #567.

## Testing

- Added `test_pop_leaf_of_dotted_key_keeps_super_table_in_output`: it fails before the fix and passes after.
- Full suite: 1053 passed, matching the pristine master baseline plus the new test. Ruff check and ruff format are clean.

## Checklist

- bug reproduced before fix
- root cause identified
- bug fixed
- tests passed
