### PR TITLE
Keep unwrap() key order after a value is replaced

### DIFF
--- a/tests/test_toml_document.py
+++ b/tests/test_toml_document.py
@@ -160,6 +160,27 @@ name = "bar"
     assert "tool" in d
 
 
+def test_unwrap_keeps_key_order_after_replacing_a_value() -> None:
+    # unwrap() reads _map, which re-inserts a replaced key and so moves it
+    # last; the order has to follow the body, like dumps() and keys() do.
+    doc = parse("a = 1\nb = 2\nc = 3\n")
+    doc["b"] = 9
+
+    assert list(doc.unwrap()) == ["a", "b", "c"]
+    assert list(doc.keys()) == ["a", "b", "c"]
+    assert tomlkit.dumps(doc) == "a = 1\nb = 9\nc = 3\n"
+
+
+def test_unwrap_follows_the_body_when_a_value_becomes_a_table() -> None:
+    # here moving the key is correct: a bare key promoted to [table] has to be
+    # emitted after the inline entries, and unwrap() should agree with dumps()
+    doc = parse("a = 1\nb = 2\n")
+    doc["a"] = {"x": 1}
+
+    assert tomlkit.dumps(doc) == 'b = 2\n\n[a]\nx = 1\n'
+    assert list(doc.unwrap()) == ["b", "a"]
+
+
 def test_toml_document_unwrap() -> None:
     content = """[tool.poetry]
 name = "foo"

--- a/tests/test_toml_document.py
+++ b/tests/test_toml_document.py
@@ -177,7 +177,7 @@ def test_unwrap_follows_the_body_when_a_value_becomes_a_table() -> None:
     doc = parse("a = 1\nb = 2\n")
     doc["a"] = {"x": 1}
 
-    assert tomlkit.dumps(doc) == 'b = 2\n\n[a]\nx = 1\n'
+    assert tomlkit.dumps(doc) == "b = 2\n\n[a]\nx = 1\n"
     assert list(doc.unwrap()) == ["b", "a"]
 
 

--- a/tomlkit/container.py
+++ b/tomlkit/container.py
@@ -67,9 +67,13 @@ class Container(_CustomDict):  # type: ignore[type-arg]
         # rebuilds a SingleKey from the bare string on every key only to throw
         # it away. Out-of-order keys (a tuple index) still go through
         # OutOfOrderTableProxy so their validation (and fragment merge) runs
-        # exactly as before. _map iterates in the same insertion order as the
-        # old self.items().
-        for key, idx in self._map.items():
+        # exactly as before. _map is keyed for lookup, not ordered: replacing a
+        # value re-inserts its key and moves it last, so take the order from the
+        # body index, which is what dumps() and items() follow.
+        for key, idx in sorted(
+            self._map.items(),
+            key=lambda item: item[1][0] if isinstance(item[1], tuple) else item[1],
+        ):
             if isinstance(idx, tuple):
                 value: Any = OutOfOrderTableProxy(self, idx)
             else:


### PR DESCRIPTION
## Summary

`unwrap()` returns keys in the wrong order after a value is replaced.

```python
doc = parse("a = 1\nb = 2\nc = 3\n")
doc["b"] = 9

dumps(doc)          # 'a = 1\nb = 9\nc = 3\n'
list(doc.keys())    # ['a', 'b', 'c']
list(doc.unwrap())  # ['a', 'c', 'b']   <-- 'b' moved to the end
```

`_replace_at` deletes the key from `_map` and re-inserts it (`container.py:916-917`), which moves it to the end of the dict's insertion order, while `_body[idx]` correctly keeps the original slot. `dumps()` and `keys()` walk `_body` and stay right; `unwrap()` walks `_map` and does not. It reproduces for every scalar and array replacement value.

This is against the README's own promise:

> a parser that preserves all comments, indentations, whitespace and **internal element ordering**
> — `README.md:18`

and against the assumption `unwrap()` was written on when it moved to `_map` in #521:

> `_map` iterates in the same insertion order as the old `self.items()`.
> — `container.py:70-71`

That sentence is true until the first replacement, which is why it held when #521 landed.

## The change

Take the order from the body index rather than from `_map` insertion order. The `_map` fast path that #521 added is kept — the point of that change was avoiding `__getitem__` rebuilding a `SingleKey` per key, and that still holds — and `dumps()` becomes the reference for order rather than a second, divergent source.

I looked at the other `_map.items()` loops before choosing this over rewriting `_replace_at`: `container.py:542` and `:583` only adjust index values and do not care about order, so `unwrap()` is the sole order-sensitive consumer.

## Not changed: replacements that genuinely move an element

A bare key promoted to a table has to be emitted after the inline entries, and `dumps()` moves it:

```python
doc = parse("a = 1\nb = 2\n")
doc["a"] = {"x": 1}
dumps(doc)          # 'b = 2\n\n[a]\nx = 1\n'
list(doc.unwrap())  # ['b', 'a']  -- correct, and unchanged by this PR
```

Ordering by the body index keeps this case as it was, since the body really did move. There is a test pinning it so the distinction cannot regress.

## Tests

Two added to `tests/test_toml_document.py`: one asserting the order is preserved on a scalar replacement, one pinning the table-promotion case above.

Verified by reverting only `tomlkit/container.py` and keeping the tests — the first fails with `assert ['a', 'c', 'b'] == ['a', 'b', 'c']`, the second still passes, so the new coverage separates the bug from the behaviour that should not change.

Full suite: 1052 passing before, 1054 after.

## Agent Drafting Metadata

- Agent: Claude Code
- Model: Claude Opus 5
- Notes: The reproduction, the red/green check and the suite runs above were executed against this branch. I reviewed and verified the change before opening the PR; happy to adjust anything on request.
