### PR TITLE
Reject trailing characters in key_value()

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -320,6 +320,50 @@ def test_key_value() -> None:
     assert isinstance(i, Integer)
 
 
+@pytest.mark.parametrize(
+    "src",
+    ["foo = 12", "foo = 12\n", "  foo = 12", "foo = 12   ", "foo = 12  # comment\n"],
+)
+def test_key_value_allows_trailing_whitespace_and_comment(src: str) -> None:
+    k, i = tomlkit.key_value(src)
+
+    assert k.key == "foo"
+    assert i == 12
+
+
+@pytest.mark.parametrize(
+    "src",
+    [
+        "foo = 12 junk",
+        "foo = 12 = 13",
+        "foo = 12]]]",
+    ],
+)
+def test_key_value_raises_on_trailing_chars(src: str) -> None:
+    # parse() rejects each of these; key_value() must agree.
+    with pytest.raises(UnexpectedCharError):
+        parse(src)
+
+    with pytest.raises(UnexpectedCharError):
+        tomlkit.key_value(src)
+
+
+def test_key_value_raises_on_a_second_pair() -> None:
+    # Two pairs are a valid document, but key_value() parses a single pair,
+    # so the second one is trailing input rather than a silently dropped value.
+    assert dict(parse("foo = 12\nbar = 13")) == {"foo": 12, "bar": 13}
+
+    with pytest.raises(UnexpectedCharError):
+        tomlkit.key_value("foo = 12\nbar = 13")
+
+
+def test_key_value_raises_on_invalid_example(
+    invalid_example: Callable[[str], str],
+) -> None:
+    with pytest.raises(UnexpectedCharError):
+        tomlkit.key_value(invalid_example("key_value_with_trailing_chars"))
+
+
 def test_string() -> None:
     s = tomlkit.string('foo "')
 

--- a/tomlkit/api.py
+++ b/tomlkit/api.py
@@ -290,12 +290,19 @@ def value(raw: str) -> _Item:
 def key_value(src: str) -> tuple[Key, _Item]:
     """Parse a key-value pair from a string.
 
+    Anything other than whitespace or a comment after the pair is an error,
+    as it is when the same text is given to :func:`parse`.
+
     :Example:
 
     >>> key_value("foo = 1")
     (Key('foo'), 1)
     """
-    return Parser(src)._parse_key_value()
+    parser = Parser(src)
+    k, v = parser._parse_key_value(parse_comment=True)
+    if not parser.end():
+        raise parser.parse_error(UnexpectedCharError, char=parser._current)
+    return k, v
 
 
 def ws(src: str) -> Whitespace:


### PR DESCRIPTION
## Summary

`tomlkit.key_value()` returned the first pair it could parse and threw away
whatever followed:

```python
>>> tomlkit.key_value("a = 1 b = 2 c = 3")
(<Key a >, 1)
```

TOML 1.0.0 ([Key/Value Pair](https://toml.io/en/v1.0.0#keyvalue-pair)) requires
a newline or EOF after a pair, and `parse()` already enforces it — each of the
inputs in the new test raises `UnexpectedCharError` there.
`tests/examples/invalid/key_value_with_trailing_chars.toml` exists for this exact
rule and its own text spells it out, but it was only ever asserted against
`parse()`.

The fix mirrors what's already next door: `value()` (api.py:283-287) guards with
`if not parser.end(): raise ...`, and the document parser reads a top-level pair
with `_parse_key_value(True)` so the comment trail is consumed. `key_value()` now
does both. Trailing whitespace, a trailing comment and a final newline stay
valid; real trailing input raises.

This follows the same call the project already made in #527, "Raise on malformed
array element instead of dropping it".

**Behaviour change:** input that was silently truncated now raises. I found no
open PR or issue touching `key_value` (checked the changed files of all 22 open
PRs; only #294 touches `api.py`, for `Decimal` codecs).

### Verification

`python -m pytest tests/ -q`, same command and environment either side:

| | result |
|---|---|
| before (tests added, `api.py` at HEAD) | `5 failed, 1057 passed` |
| after | `1062 passed` |

I also checked the naive version of this fix — the `end()` guard alone, without
`parse_comment=True`. It fails 3 of the new cases (`"foo = 12\n"`,
`"foo = 12   "`, `"foo = 12  # comment\n"`), which is why those are in the test.

## Agent Drafting Metadata

- Agent: Claude Code
- Model: Claude Opus 5 (`claude-opus-5`)
- Notes: Found by comparing the public helpers in `api.py` against each other —
  `key_value()` was the only one with a single test reference, and the sibling
  `value()` had the end-of-input guard it was missing. The diff, tests and this
  description were drafted with the agent and reviewed before submission.
