### PR TITLE
Reject array slice assignment before mutating values

### DIFF
--- a/tests/test_items.py
+++ b/tests/test_items.py
@@ -311,6 +311,36 @@ def test_key_automatically_sets_proper_string_type_if_not_bare() -> None:
     assert key.t == KeyType.Basic
 
 
+@pytest.mark.parametrize(
+    "index, replacement",
+    [
+        (slice(None), [4, 5, 6]),
+        (slice(1, 2), [4, 5]),
+        (slice(1, 1), [4]),
+        (slice(1, 3), []),
+        (slice(None, None, 2), [4, 5]),
+        (slice(None, None, -1), [4, 5, 6]),
+    ],
+)
+def test_array_slice_assignment_does_not_mutate(
+    index: slice, replacement: list[int]
+) -> None:
+    content = "a = [\n    1, # first\n    2,\n    3,\n]\n"
+    doc = parse(content)
+    a = doc["a"]
+
+    with pytest.raises(ValueError, match="slice assignment is not supported"):
+        a[index] = replacement
+
+    assert a == [1, 2, 3]
+    assert doc.as_string() == content
+
+    a[-1] = 4
+    a.append(5)
+    assert a == [1, 2, 4, 5]
+    assert parse(doc.as_string())["a"] == a
+
+
 def test_array_behaves_like_a_list() -> None:
     a = item([1, 2])
 

--- a/tomlkit/items.py
+++ b/tomlkit/items.py
@@ -1584,10 +1584,10 @@ class Array(Item, _CustomList):  # type: ignore[type-arg]
         return list.__getitem__(self, key)
 
     def __setitem__(self, key: int | slice, value: Any) -> None:  # type: ignore[override]
-        it = item(value, _parent=self)
-        list.__setitem__(self, key, it)
         if isinstance(key, slice):
             raise ValueError("slice assignment is not supported")
+        it = item(value, _parent=self)
+        list.__setitem__(self, key, it)
         if key < 0:
             key += len(self)
         self._value[self._index_map[key]].value = it


### PR DESCRIPTION
## Summary

`Array.__setitem__` rejects slice assignment only after modifying the underlying list. For example, assigning `[9, 10]` to `a[1:2]` on `[1, 2, 3]` raises `ValueError`, but leaves the in-memory value as `[1, 9, 10, 3]` while serialization still produces `[1, 2, 3]`.

Check for unsupported slices before converting or assigning the replacement. The six regression cases cover replacement, insertion, deletion through assignment, and extended/reversed slices. They assert that values and the original commented TOML remain unchanged after the exception, and that subsequent supported edits still round-trip.

Validation on Windows with Python 3.12.10: all 1,058 tests pass, including the TOML conformance suite. All six new cases fail on the unmodified implementation. All configured pre-commit hooks pass on the tracked repository files. Full mypy reports the same 29 diagnostics on both this branch and the unmodified upstream commit (five in project code and 24 in the test submodule).

Related: #599 addresses slice deletion in `__delitem__`; this change concerns rejected slice assignment in `__setitem__`.

## Agent Drafting Metadata

- Agent: OpenAI Codex
- Model: GPT-6
- Notes: AI-assisted investigation, implementation, regression tests, and PR drafting. The reproduction and reported checks were executed locally.
