### PR TITLE
Render each run of a split array of tables where it was written

### DIFF
--- a/tests/test_toml_document.py
+++ b/tests/test_toml_document.py
@@ -1583,20 +1583,7 @@ name = "Hammer"
 [[products]]
 name = "Nail"'''
     doc = parse(content)
-    assert (
-        doc.as_string()
-        == """\
-[[products]]
-name = "Hammer"
-
-[[products]]
-name = "Nail"
-[foo]
-
-[bar]
-
-"""
-    )
+    assert doc.as_string() == content
     assert doc == {
         "products": [
             {"name": "Hammer"},
@@ -1666,3 +1653,95 @@ a.b = 1
     doc["z"] = 2
 
     assert doc.as_string() == "a.b = 1\nz = 2\n"
+
+
+def test_split_array_of_tables_keeps_document_order() -> None:
+    content = """\
+[[fruit]]
+name = "apple"
+
+[settings]
+color = true
+
+[[fruit]]
+name = "banana"
+
+[[fruit]]
+name = "cherry"
+"""
+    doc = parse(content)
+
+    assert doc.as_string() == content
+    assert [table["name"] for table in doc["fruit"]] == ["apple", "banana", "cherry"]
+    assert doc.unwrap() == {
+        "fruit": [{"name": "apple"}, {"name": "banana"}, {"name": "cherry"}],
+        "settings": {"color": True},
+    }
+
+
+def test_split_array_of_tables_appends_to_the_last_run() -> None:
+    content = """\
+[[fruit]]
+name = "apple"
+
+[settings]
+color = true
+
+[[fruit]]
+name = "banana"
+"""
+    doc = parse(content)
+    table = tomlkit.table()
+    table["name"] = "cherry"
+    doc["fruit"].append(table)
+
+    assert len(doc["fruit"]) == 3
+    assert doc.as_string().index("cherry") > doc.as_string().index("color")
+
+
+def test_split_array_of_tables_after_deleting_the_start_of_a_run() -> None:
+    content = """\
+[[fruit]]
+name = "apple"
+
+[settings]
+color = true
+
+[[fruit]]
+name = "banana"
+
+[[fruit]]
+name = "cherry"
+"""
+    doc = parse(content)
+    del doc["fruit"][1]
+
+    assert (
+        doc.as_string()
+        == """\
+[[fruit]]
+name = "apple"
+
+[settings]
+color = true
+
+[[fruit]]
+name = "cherry"
+"""
+    )
+
+
+def test_split_array_of_tables_survives_a_copy() -> None:
+    content = """\
+[[fruit]]
+name = "apple"
+
+[settings]
+color = true
+
+[[fruit]]
+name = "banana"
+"""
+    doc = parse(content)
+
+    assert copy.deepcopy(doc).as_string() == content

--- a/tomlkit/container.py
+++ b/tomlkit/container.py
@@ -32,6 +32,27 @@ from tomlkit.items import item as _item
 _NOT_SET = object()
 
 
+class _AoTContinuation(Null):
+    """Body entry standing in for a later run of an array-of-tables header.
+
+    ``[[a]] ... [b] ... [[a]]`` is one array whose headers are written in two
+    runs. The elements live in a single :class:`AoT` so that ``doc["a"]`` is
+    that whole array; this marker records where a later run was written so it
+    renders back in place instead of being pulled up to the first run.
+    """
+
+    def __init__(self, key: Key, aot: AoT, tables: list[Table]) -> None:
+        super().__init__()
+        self.key = key
+        self.aot = aot
+        self.tables = tables
+
+    def _getstate(  # type: ignore[override]
+        self, protocol: int = 3
+    ) -> tuple[Key, AoT, list[Table]]:
+        return self.key, self.aot, self.tables
+
+
 class Container(_CustomDict):  # type: ignore[type-arg]
     """
     A container for items within a TOMLDocument.
@@ -53,6 +74,9 @@ class Container(_CustomDict):  # type: ignore[type-arg]
         # out-of-order tables doesn't have to scan every key in the map;
         # stale entries are filtered by the per-key isinstance check
         self._out_of_order_keys: set[Key] = set()
+        # whether any array of tables in this body is written as several runs;
+        # false for almost every document, and rendering skips a pass when so
+        self._has_aot_continuation = False
 
     @property
     def body(self) -> list[tuple[Key | None, Item]]:
@@ -366,8 +390,19 @@ class Container(_CustomDict):  # type: ignore[type-arg]
                     # Tried to define an AoT after a table with the same name.
                     raise KeyAlreadyPresent(key)
 
+                start = len(current.body)
                 for table in item.body:
                     current.append(table)
+
+                if self._parsed and len(current.body) > start:
+                    self._has_aot_continuation = True
+                    # A second run of ``[[key]]`` headers, separated from the
+                    # first by an unrelated table. The elements all belong to
+                    # the one array, but the run has to render back where it
+                    # was written, so remember where it starts.
+                    self._body.append(
+                        (None, _AoTContinuation(key, current, current.body[start:]))
+                    )
 
                 return self
             else:
@@ -633,7 +668,13 @@ class Container(_CustomDict):  # type: ignore[type-arg]
     def as_string(self) -> str:
         """Render as TOML string."""
         s = ""
+        ranges = self._aot_render_ranges() if self._has_aot_continuation else {}
         for k, v in self._body:
+            if isinstance(v, _AoTContinuation):
+                start, end = ranges[id(v)]
+                if start != end:
+                    s += self._render_aot(v.key, v.aot, body=v.aot.body[start:end])
+                continue
             if k is not None:
                 if isinstance(v, Table):
                     if (
@@ -650,13 +691,58 @@ class Container(_CustomDict):  # type: ignore[type-arg]
                         and "\n" not in v.trivia.indent
                     ):
                         s += "\n"
-                    s += self._render_aot(k, v)
+                    aot_range = ranges.get(id(v))
+                    body = None if aot_range is None else v.body[slice(*aot_range)]
+                    s += self._render_aot(k, v, body=body)
                 else:
                     s += self._render_simple_item(k, v)
             else:
                 s += self._render_simple_item(k, v)
 
         return s
+
+    def _aot_render_ranges(self) -> dict[int, tuple[int, int]]:
+        """Map each split array-of-tables run to the elements it renders.
+
+        An array of tables interrupted by an unrelated table is stored as a
+        single ``AoT`` plus one ``_AoTContinuation`` marker per later run. The
+        keys of the returned mapping are the ``id()`` of the ``AoT`` (its first
+        run) and of each marker.  An empty mapping is the common case.
+        """
+        markers: dict[int, list[_AoTContinuation]] = {}
+
+        for _, v in self._body:
+            if isinstance(v, _AoTContinuation):
+                markers.setdefault(id(v.aot), []).append(v)
+
+        ranges: dict[int, tuple[int, int]] = {}
+        for conts in markers.values():
+            aot = conts[0].aot
+            position = {id(table): i for i, table in enumerate(aot.body)}
+            live: list[_AoTContinuation] = []
+            bounds: list[int] = [0]
+            for cont in conts:
+                # Elements can have been deleted since parsing, so the run
+                # starts at the first of its elements that is still there. If
+                # none is, the run renders nothing.
+                start = next(
+                    (
+                        position[id(table)]
+                        for table in cont.tables
+                        if id(table) in position
+                    ),
+                    None,
+                )
+                if start is not None and start >= bounds[-1]:
+                    live.append(cont)
+                    bounds.append(start)
+                else:
+                    ranges[id(cont)] = (0, 0)
+            bounds.append(len(aot.body))
+            ranges[id(aot)] = (0, bounds[1])
+            for n, cont in enumerate(live):
+                ranges[id(cont)] = (bounds[n + 1], bounds[n + 2])
+        return ranges
 
     def _render_table(self, key: Key, table: Table, prefix: str | None = None) -> str:
         cur = ""
@@ -740,14 +826,20 @@ class Container(_CustomDict):  # type: ignore[type-arg]
 
         return cur
 
-    def _render_aot(self, key: Key, aot: AoT, prefix: str | None = None) -> str:
+    def _render_aot(
+        self,
+        key: Key,
+        aot: AoT,
+        prefix: str | None = None,
+        body: list[Table] | None = None,
+    ) -> str:
         _key = key.as_string()
         if prefix is not None:
             _key = prefix + "." + _key
 
         cur = ""
         _key = decode(_key)
-        for table in aot.body:
+        for table in aot.body if body is None else body:
             cur += self._render_aot_table(table, prefix=_key)
 
         return cur
@@ -1012,6 +1104,9 @@ class Container(_CustomDict):  # type: ignore[type-arg]
         self._out_of_order_keys = {
             k for k, v in self._map.items() if isinstance(v, tuple)
         }
+        self._has_aot_continuation = any(
+            isinstance(v, _AoTContinuation) for _, v in self._body
+        )
 
         for key, item in self._body:
             if key is not None:


### PR DESCRIPTION
## Summary

`tomlkit.dumps(tomlkit.parse(s))` does not return `s` when a document interrupts an array of tables with an unrelated table and then continues it. The intervening table is moved below the whole array.

I did not find an existing issue for this, so there is no issue number to reference.

## Reproduction

```python
import tomlkit

content = """\
[[fruit]]
name = "apple"

[settings]
color = true

[[fruit]]
name = "banana"
"""

print(tomlkit.dumps(tomlkit.parse(content)))
```

On `master` (4b38bec):

```
[[fruit]]
name = "apple"

[[fruit]]
name = "banana"
[settings]
color = true

```

`[settings]` has moved, and the blank line before it is gone. Nothing was modified between the parse and the dump. The document is valid TOML 1.0.0 — a table header may interrupt an array of tables and a later `[[fruit]]` continues the same array — and the parse is correct: `doc["fruit"]` is the two-element array. Only the rendering is wrong.

With this branch the input is reproduced byte for byte.

## Cause

`Parser._parse_aot` gathers only *contiguous* `[[fruit]]` headers, so the second run reaches `Container.append` as a separate `AoT` under a key that is already present. That branch merged the new elements into the existing `AoT` and returned:

```python
elif isinstance(item, AoT):
    ...
    for table in item.body:
        current.append(table)

    return self
```

Once merged, nothing recorded that a run had been written further down, and `as_string` rendered the entire array at the first run's body position.

## Approach

The elements stay in one `AoT`, so `doc["fruit"]` is still the whole array and every existing accessor, `unwrap()` and mutation path is unchanged. What is added is a marker in the container body, `_AoTContinuation`, recording that a later run was written at that point and which elements it began with. `as_string` renders the `AoT` up to the first marker, and each marker renders its own slice in place.

The alternative I tried first was the one the out-of-order *table* path uses: give the run its own body entry, make `_map[key]` a tuple, and merge the runs on access. It fixes the rendering just as well, but `doc["fruit"]` then has to be a merged copy, and `doc["fruit"].append(table)` silently does nothing. That seemed worse than the bug, so I went with the marker. If you would rather have the split represented in `_map` — in line with how out-of-order tables work — I am happy to redo it that way; it would want an AoT-shaped proxy to keep mutation working.

Behaviour of the marker after parsing:

- elements appended later go to the end of the array, so they render with the last run;
- deleting the element a run started at moves the run to its next surviving element;
- deleting every element of a run makes it render nothing.

There are tests for the first and second of these.

## On the changed test

`test_parse_aot_without_ending_newline` asserted the reordered output. It came from #422 / #381, which was about a missing final newline corrupting the dump, and the expectation simply captured what the renderer did at the time. It now asserts that the document is preserved; the `doc == {...}` half of the test is unchanged and still passes.

## What I verified

- Full suite on macOS arm64, Python 3.14.4: `1062 passed`. CI will need to confirm the other versions and Linux.
- `ruff check` and `mypy` report exactly the same pre-existing findings before and after the change (3 and 97 respectively, none in the lines touched).
- Round-trip fuzzing over ~40k generated documents (key/value styles, comments, whitespace, `[t]`, `[t.sub]` and `[[arr]]` headers): before, 464 documents did not round-trip and every one was this bug; after, none.
- `copy.deepcopy` and `pickle` round-trips of a split array (the marker needed a `_getstate`, and `Container.__setstate__` recomputes the flag).

Rendering does one extra pass over the body to locate markers. It is guarded by a flag set only when a split array is actually parsed, so documents without one — nearly all of them — are untouched.

## Adjacent, not fixed here

The same fuzzing shows a *sub-table* of an array element is still pulled up out of order:

```toml
[[arr]]
[t2]
[arr.sub]
```

dumps as `[[arr]]` / `[arr.sub]` / `[t2]`. That is a different code path (the `is_super_table()` branch just above the one changed here), so I left it alone rather than widen this PR. Happy to open an issue for it.

## Agent Drafting Metadata

- Agent: Claude Code
- Model: Claude Opus 5
- Notes: The bug was found by property-fuzzing `dumps(parse(s)) == s`, not from an issue report. Diagnosis, the choice between the two approaches, the patch and the tests were drafted with the agent and reviewed and run locally by me; all output quoted above is from real runs on this branch.
